### PR TITLE
chore: migrate from git submodules to soldeer (#32)

### DIFF
--- a/.github/workflows/publish-soldeer.yaml
+++ b/.github/workflows/publish-soldeer.yaml
@@ -29,4 +29,4 @@ jobs:
           SOLDEER_API_TOKEN: ${{ secrets.SOLDEER_API_TOKEN }}
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          nix develop -c forge soldeer push "rain.solmem~${VERSION}" --skip-warnings
+          nix develop -c forge soldeer push "rain.solmem~${VERSION}"

--- a/.github/workflows/publish-soldeer.yaml
+++ b/.github/workflows/publish-soldeer.yaml
@@ -1,0 +1,33 @@
+name: Publish to Soldeer
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (e.g. 0.1.0). No leading 'v'."
+        required: true
+        type: string
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - uses: nixbuild/nix-quick-install-action@v30
+        with:
+          nix_conf: |
+            keep-env-derivations = true
+            keep-outputs = true
+      - name: Restore and save Nix store
+        uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 1G
+
+      - run: nix develop -c forge soldeer push rain.solmem~${{ inputs.version }} --skip-warnings
+        env:
+          SOLDEER_API_TOKEN: ${{ secrets.SOLDEER_API_TOKEN }}

--- a/.github/workflows/publish-soldeer.yaml
+++ b/.github/workflows/publish-soldeer.yaml
@@ -1,11 +1,8 @@
 name: Publish to Soldeer
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: "Version to publish (e.g. 0.1.0). No leading 'v'."
-        required: true
-        type: string
+  push:
+    tags:
+      - "v*"
 
 jobs:
   publish:
@@ -13,7 +10,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: recursive
           fetch-depth: 0
 
       - uses: nixbuild/nix-quick-install-action@v30
@@ -28,6 +24,9 @@ jobs:
           restore-prefixes-first-match: nix-${{ runner.os }}-
           gc-max-store-size-linux: 1G
 
-      - run: nix develop -c forge soldeer push rain.solmem~${{ inputs.version }} --skip-warnings
+      - name: Push to Soldeer
         env:
           SOLDEER_API_TOKEN: ${{ secrets.SOLDEER_API_TOKEN }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          nix develop -c forge soldeer push "rain.solmem~${VERSION}" --skip-warnings

--- a/.github/workflows/rainix.yaml
+++ b/.github/workflows/rainix.yaml
@@ -33,8 +33,8 @@ jobs:
           # 1G = 1073741824
           gc-max-store-size-linux: 1G
 
-      - run: nix develop -c rainix-sol-prelude
       - run: nix develop -c forge soldeer install
+      - run: nix develop -c rainix-sol-prelude
       - name: Run ${{ matrix.task }}
         env:
           ETH_RPC_URL: ${{ secrets.CI_DEPLOY_RPC_URL }}

--- a/.github/workflows/rainix.yaml
+++ b/.github/workflows/rainix.yaml
@@ -34,7 +34,6 @@ jobs:
           gc-max-store-size-linux: 1G
 
       - run: nix develop -c forge soldeer install
-      - run: nix develop -c rainix-sol-prelude
       - name: Run ${{ matrix.task }}
         env:
           ETH_RPC_URL: ${{ secrets.CI_DEPLOY_RPC_URL }}

--- a/.github/workflows/rainix.yaml
+++ b/.github/workflows/rainix.yaml
@@ -14,7 +14,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: recursive
           fetch-depth: 0
 
       - uses: nixbuild/nix-quick-install-action@v30
@@ -35,6 +34,7 @@ jobs:
           gc-max-store-size-linux: 1G
 
       - run: nix develop -c rainix-sol-prelude
+      - run: nix develop -c forge soldeer install
       - name: Run ${{ matrix.task }}
         env:
           ETH_RPC_URL: ${{ secrets.CI_DEPLOY_RPC_URL }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ cache
 out
 docs
 .DS_Store
+
+# Soldeer
+/dependencies

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "lib/forge-std"]
-	path = lib/forge-std
-	url = https://github.com/foundry-rs/forge-std

--- a/.soldeerignore
+++ b/.soldeerignore
@@ -1,0 +1,17 @@
+.git
+.github
+.gitignore
+.gitmodules
+audit
+cache
+dependencies
+docs
+flake.lock
+flake.nix
+foundry.lock
+lib
+out
+remappings.txt
+soldeer.lock
+target
+test

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -15,6 +15,9 @@ path = [
     "slither.config.json",
     "REUSE.toml",
     "foundry.lock",
+    ".soldeerignore",
+    "remappings.txt",
+    "soldeer.lock",
 ]
 SPDX-FileCopyrightText = "Copyright (c) 2020 Rain Open Source Software Ltd"
 SPDX-License-Identifier = "LicenseRef-DCL-1.0"

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -75,16 +91,58 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1768892915,
-        "narHash": "sha256-2+KHmLLjUg9vNzINfGaiFNP07gKz94Af09FcefKHUuE=",
+        "lastModified": 1773213477,
+        "narHash": "sha256-Pv1Z3QqGkSGEUV+9pM5vYIiI7VJo7Tfm6ZmR+JSp1zo=",
         "owner": "shazow",
         "repo": "foundry.nix",
-        "rev": "edf14357ad1816ac39469ae493f898200352d77d",
+        "rev": "3c73daa86c823d706824fd9bbcb85aa23fd0f668",
         "type": "github"
       },
       "original": {
         "owner": "shazow",
         "repo": "foundry.nix",
+        "type": "github"
+      }
+    },
+    "git-hooks-nix": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1774104215,
+        "narHash": "sha256-EAtviqz0sEAxdHS4crqu7JGR5oI3BwaqG0mw7CmXkO8=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "f799ae951fde0627157f40aec28dec27b22076d0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "rainix",
+          "git-hooks-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
         "type": "github"
       }
     },
@@ -120,11 +178,27 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1768987938,
-        "narHash": "sha256-pvqBRTCRvwFM0Nm7aCQfqS0whDZ7WwoXUUTwvOXqus4=",
+        "lastModified": 1770073757,
+        "narHash": "sha256-Vy+G+F+3E/Tl+GMNgiHl9Pah2DgShmIUBJXmbiQPHbI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "47472570b1e607482890801aeaf29bfb749884f6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1776017067,
+        "narHash": "sha256-oEp8fqJweZd5doqvH/aBAtc6NzZh+fh0tOhR09gQXck=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "95d8e2129409fd37b390c966b434eee3034f75e3",
+        "rev": "a5a7cf16648d79134eb4da0e3354b08913917b2f",
         "type": "github"
       },
       "original": {
@@ -133,7 +207,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_3": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1744536153,
         "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
@@ -149,13 +223,13 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_5": {
       "locked": {
-        "lastModified": 1766653575,
-        "narHash": "sha256-TPgxCS7+hWc4kPhzkU5dD2M5UuPhLuuaMNZ/IpwKQvI=",
+        "lastModified": 1771923393,
+        "narHash": "sha256-Fy0+UXELv9hOE8WjYhJt8fMDLYTU2Dqn3cX4BwoGBos=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3c1016e6acd16ad96053116d0d3043029c9e2649",
+        "rev": "ea7f1f06811ce7fcc81d6c6fd4213150c23edcf2",
         "type": "github"
       },
       "original": {
@@ -169,17 +243,18 @@
       "inputs": {
         "flake-utils": "flake-utils_2",
         "foundry": "foundry",
-        "nixpkgs": "nixpkgs_2",
+        "git-hooks-nix": "git-hooks-nix",
+        "nixpkgs": "nixpkgs_3",
         "nixpkgs-old": "nixpkgs-old",
         "rust-overlay": "rust-overlay",
         "solc": "solc"
       },
       "locked": {
-        "lastModified": 1768991906,
-        "narHash": "sha256-W8AgvEKkz4BWTHDK3AGwk/vvVFtIF7UtHuZI8Ecv2qI=",
+        "lastModified": 1778319813,
+        "narHash": "sha256-wpCQGVsY/+FGdqPzUIyNaEp7g74GNwTvBzMCq8/kUzA=",
         "owner": "rainprotocol",
         "repo": "rainix",
-        "rev": "5a9f13de1318b512ef118db6d0e7f9dbafe5205f",
+        "rev": "8603a225676b3d4d6d7cd0e41ae8918aa2ee4bf5",
         "type": "github"
       },
       "original": {
@@ -196,14 +271,14 @@
     },
     "rust-overlay": {
       "inputs": {
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1768963622,
-        "narHash": "sha256-n6VHiUgrYD9yjagzG6ncVVqFbVTsKCI54tR9PNAFCo0=",
+        "lastModified": 1773216618,
+        "narHash": "sha256-iZlowevS+xKLGOXtZwpIrz3SWe7PtoGUfEeVZNib+WE=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "2ef5b3362af585a83bafd34e7fc9b1f388c2e5e2",
+        "rev": "07d7dc6fcc5eae76b4fb0e19d4afd939437bec97",
         "type": "github"
       },
       "original": {
@@ -215,15 +290,15 @@
     "solc": {
       "inputs": {
         "flake-utils": "flake-utils_4",
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": "nixpkgs_5",
         "solc-macos-amd64-list-json": "solc-macos-amd64-list-json"
       },
       "locked": {
-        "lastModified": 1768831671,
-        "narHash": "sha256-0mmlYRtZK+eomevkQCCH7PL8QlSuALZQsjLroCWGE08=",
+        "lastModified": 1772085240,
+        "narHash": "sha256-+NEcuhT2A0QQumVx9Ze6g2iuNicyuW028Jq/HUJHGh4=",
         "owner": "hellwolf",
         "repo": "solc.nix",
-        "rev": "80ad871b93d15c7bccf71617f78f73c2d291a9c7",
+        "rev": "d3cc119973e484ea366f4b997b404bb00d7829ca",
         "type": "github"
       },
       "original": {
@@ -235,13 +310,13 @@
     "solc-macos-amd64-list-json": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-P+ZslplK4cQ/wnV/wykVKb+yTCviI0eylA3sk9uHmRo=",
+        "narHash": "sha256-oEiXc95EghuYCudzkPA9XBFOnMdgWFfTO2/4XUfSTpc=",
         "type": "file",
-        "url": "https://github.com/argotorg/solc-bin/raw/a11f1ad/macosx-amd64/list.json"
+        "url": "https://github.com/argotorg/solc-bin/raw/83cb756/macosx-amd64/list.json"
       },
       "original": {
         "type": "file",
-        "url": "https://github.com/argotorg/solc-bin/raw/a11f1ad/macosx-amd64/list.json"
+        "url": "https://github.com/argotorg/solc-bin/raw/83cb756/macosx-amd64/list.json"
       }
     },
     "systems": {

--- a/flake.lock
+++ b/flake.lock
@@ -250,11 +250,11 @@
         "solc": "solc"
       },
       "locked": {
-        "lastModified": 1778319813,
-        "narHash": "sha256-wpCQGVsY/+FGdqPzUIyNaEp7g74GNwTvBzMCq8/kUzA=",
+        "lastModified": 1778347254,
+        "narHash": "sha256-zfYtCbqg8/dYLcUcsxxTQhhgkcdU3QK3g7mzEogl/y0=",
         "owner": "rainprotocol",
         "repo": "rainix",
-        "rev": "8603a225676b3d4d6d7cd0e41ae8918aa2ee4bf5",
+        "rev": "15992676b0a12409c82879c050e65fcf65cef155",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
         pkgs = rainix.pkgs.${system};
       in {
         packages = rainix.packages.${system};
-        devShells = rainix.devShells.${system};
+        devShells.default = rainix.devShells.${system}.sol-shell;
       }
     );
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -8,3 +8,7 @@ optimizer_runs = 100000
 evm_version = "cancun"
 
 fuzz.runs = 2056
+libs = ["dependencies"]
+
+[dependencies]
+forge-std = "1.16.1"

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,0 +1,1 @@
+forge-std-1.16.1/=dependencies/forge-std-1.16.1/

--- a/soldeer.lock
+++ b/soldeer.lock
@@ -1,0 +1,6 @@
+[[dependencies]]
+name = "forge-std"
+version = "1.16.1"
+url = "https://soldeer-revisions.s3.amazonaws.com/forge-std/1_16_1_08-05-2026_08:51:16_forge-std-1.16.zip"
+checksum = "839b61832925c7152c7b6dffbfa4998d9e606211179bd8f604733124e8a7cb57"
+integrity = "60e55d10150354ca4a1e2985c5456c834b92b82ef85ab0e1d92a7786cddbd219"

--- a/test/src/lib/LibBytes.t.sol
+++ b/test/src/lib/LibBytes.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std/Test.sol";
+import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibBytes, TruncateError} from "src/lib/LibBytes.sol";
 import {LibPointer, Pointer, LibMemCpy} from "src/lib/LibMemCpy.sol";
 

--- a/test/src/lib/LibBytes32Array.arrayFrom.t.sol
+++ b/test/src/lib/LibBytes32Array.arrayFrom.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std/Test.sol";
+import {Test} from "forge-std-1.16.1/src/Test.sol";
 
 import {LibBytes32Array, Pointer} from "src/lib/LibBytes32Array.sol";
 import {LibPointer} from "src/lib/LibPointer.sol";

--- a/test/src/lib/LibBytes32Array.extend.t.sol
+++ b/test/src/lib/LibBytes32Array.extend.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std/Test.sol";
+import {Test} from "forge-std-1.16.1/src/Test.sol";
 
 import {LibBytes32Array} from "src/lib/LibBytes32Array.sol";
 import {LibBytes32ArraySlow} from "test/lib/LibBytes32ArraySlow.sol";

--- a/test/src/lib/LibBytes32Array.pointer.t.sol
+++ b/test/src/lib/LibBytes32Array.pointer.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std/Test.sol";
+import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibBytes32Array, Pointer} from "src/lib/LibBytes32Array.sol";
 
 contract LibBytes32ArrayPointerTest is Test {

--- a/test/src/lib/LibBytes32Array.reverse.t.sol
+++ b/test/src/lib/LibBytes32Array.reverse.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std/Test.sol";
+import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibBytes32Array} from "src/lib/LibBytes32Array.sol";
 import {LibBytes32ArraySlow} from "test/lib/LibBytes32ArraySlow.sol";
 

--- a/test/src/lib/LibBytes32Array.truncate.t.sol
+++ b/test/src/lib/LibBytes32Array.truncate.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std/Test.sol";
+import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibBytes32Array} from "src/lib/LibBytes32Array.sol";
 import {OutOfBoundsTruncate} from "src/error/ErrUint256Array.sol";
 import {LibBytes32ArraySlow} from "test/lib/LibBytes32ArraySlow.sol";

--- a/test/src/lib/LibBytes32Matrix.flatten.t.sol
+++ b/test/src/lib/LibBytes32Matrix.flatten.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std/Test.sol";
+import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibBytes32Matrix} from "src/lib/LibBytes32Matrix.sol";
 import {LibBytes32MatrixSlow} from "test/lib/LibBytes32MatrixSlow.sol";
 

--- a/test/src/lib/LibBytes32Matrix.itemCount.t.sol
+++ b/test/src/lib/LibBytes32Matrix.itemCount.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std/Test.sol";
+import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibBytes32Matrix} from "src/lib/LibBytes32Matrix.sol";
 import {LibBytes32MatrixSlow} from "test/lib/LibBytes32MatrixSlow.sol";
 

--- a/test/src/lib/LibBytes32Matrix.matrixFrom.t.sol
+++ b/test/src/lib/LibBytes32Matrix.matrixFrom.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std/Test.sol";
+import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibBytes32Array} from "src/lib/LibBytes32Array.sol";
 import {LibBytes32Matrix, LibPointer, Pointer} from "src/lib/LibBytes32Matrix.sol";
 

--- a/test/src/lib/LibBytes32Matrix.pointer.t.sol
+++ b/test/src/lib/LibBytes32Matrix.pointer.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std/Test.sol";
+import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibBytes32Matrix, Pointer} from "src/lib/LibBytes32Matrix.sol";
 
 import {LibBytes32MatrixSlow} from "test/lib/LibBytes32MatrixSlow.sol";

--- a/test/src/lib/LibMemCpy.Bytes.t.sol
+++ b/test/src/lib/LibMemCpy.Bytes.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std/Test.sol";
+import {Test} from "forge-std-1.16.1/src/Test.sol";
 
 import {LibMemCpy} from "src/lib/LibMemCpy.sol";
 import {Pointer, LibBytes} from "src/lib/LibBytes.sol";

--- a/test/src/lib/LibMemCpy.Words.t.sol
+++ b/test/src/lib/LibMemCpy.Words.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std/Test.sol";
+import {Test} from "forge-std-1.16.1/src/Test.sol";
 
 import {LibMemCpy} from "src/lib/LibMemCpy.sol";
 import {LibUint256Array, Pointer} from "src/lib/LibUint256Array.sol";

--- a/test/src/lib/LibPointer.t.sol
+++ b/test/src/lib/LibPointer.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std/Test.sol";
+import {Test} from "forge-std-1.16.1/src/Test.sol";
 
 import {LibPointer, Pointer} from "src/lib/LibPointer.sol";
 import {LibBytes} from "src/lib/LibBytes.sol";

--- a/test/src/lib/LibStackPointer.t.sol
+++ b/test/src/lib/LibStackPointer.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std/Test.sol";
+import {Test} from "forge-std-1.16.1/src/Test.sol";
 
 import {LibPointer} from "src/lib/LibPointer.sol";
 import {LibStackPointer} from "src/lib/LibStackPointer.sol";

--- a/test/src/lib/LibStackPointer.toIndexSigned.t.sol
+++ b/test/src/lib/LibStackPointer.toIndexSigned.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std/Test.sol";
+import {Test} from "forge-std-1.16.1/src/Test.sol";
 
 import {LibPointer, Pointer} from "src/lib/LibPointer.sol";
 import {LibStackPointer} from "src/lib/LibStackPointer.sol";

--- a/test/src/lib/LibStackSentinel.t.sol
+++ b/test/src/lib/LibStackSentinel.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std/Test.sol";
+import {Test} from "forge-std-1.16.1/src/Test.sol";
 
 import {LibPointer, Pointer} from "src/lib/LibPointer.sol";
 import {LibUint256Array} from "src/lib/LibStackPointer.sol";

--- a/test/src/lib/LibUint256Array.arrayFrom.t.sol
+++ b/test/src/lib/LibUint256Array.arrayFrom.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std/Test.sol";
+import {Test} from "forge-std-1.16.1/src/Test.sol";
 
 import {LibUint256Array, Pointer} from "src/lib/LibUint256Array.sol";
 import {LibPointer} from "src/lib/LibPointer.sol";

--- a/test/src/lib/LibUint256Array.extend.t.sol
+++ b/test/src/lib/LibUint256Array.extend.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std/Test.sol";
+import {Test} from "forge-std-1.16.1/src/Test.sol";
 
 import {LibUint256Array} from "src/lib/LibUint256Array.sol";
 import {LibUint256ArraySlow} from "test/lib/LibUint256ArraySlow.sol";

--- a/test/src/lib/LibUint256Array.pointer.t.sol
+++ b/test/src/lib/LibUint256Array.pointer.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std/Test.sol";
+import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibUint256Array, Pointer} from "src/lib/LibUint256Array.sol";
 
 contract LibUint256ArrayPointerTest is Test {

--- a/test/src/lib/LibUint256Array.reverse.t.sol
+++ b/test/src/lib/LibUint256Array.reverse.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std/Test.sol";
+import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibUint256Array} from "src/lib/LibUint256Array.sol";
 import {LibUint256ArraySlow} from "test/lib/LibUint256ArraySlow.sol";
 

--- a/test/src/lib/LibUint256Array.truncate.t.sol
+++ b/test/src/lib/LibUint256Array.truncate.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std/Test.sol";
+import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibUint256Array} from "src/lib/LibUint256Array.sol";
 import {OutOfBoundsTruncate} from "src/error/ErrUint256Array.sol";
 import {LibUint256ArraySlow} from "test/lib/LibUint256ArraySlow.sol";

--- a/test/src/lib/LibUint256Matrix.flatten.t.sol
+++ b/test/src/lib/LibUint256Matrix.flatten.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std/Test.sol";
+import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibUint256Matrix} from "src/lib/LibUint256Matrix.sol";
 import {LibUint256MatrixSlow} from "test/lib/LibUint256MatrixSlow.sol";
 

--- a/test/src/lib/LibUint256Matrix.itemCount.t.sol
+++ b/test/src/lib/LibUint256Matrix.itemCount.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std/Test.sol";
+import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibUint256Matrix} from "src/lib/LibUint256Matrix.sol";
 import {LibUint256MatrixSlow} from "test/lib/LibUint256MatrixSlow.sol";
 

--- a/test/src/lib/LibUint256Matrix.matrixFrom.t.sol
+++ b/test/src/lib/LibUint256Matrix.matrixFrom.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std/Test.sol";
+import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibUint256Array} from "src/lib/LibUint256Array.sol";
 import {LibUint256Matrix, LibPointer, Pointer} from "src/lib/LibUint256Matrix.sol";
 

--- a/test/src/lib/LibUint256Matrix.pointer.t.sol
+++ b/test/src/lib/LibUint256Matrix.pointer.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std/Test.sol";
+import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibUint256Matrix, Pointer} from "src/lib/LibUint256Matrix.sol";
 
 import {LibUint256MatrixSlow} from "test/lib/LibUint256MatrixSlow.sol";


### PR DESCRIPTION
## Summary

Closes #32. Migrates this repo from git submodules to soldeer, the first level-1 leaf in the rainlanguage soldeer migration tracked at https://github.com/rainlanguage/rain.math.float/issues/194.

## What changed

- `forge soldeer init --clean` removed `lib/` and the `forge-std` submodule pointer; generated `foundry.toml` `[dependencies]`, `soldeer.lock`, `remappings.txt`, and added `/dependencies` to `.gitignore`.
- Versioned soldeer-default remapping (`forge-std-1.16.1/=...`) is the convention chosen here. Updated 25 test files to import via the versioned prefix (`forge-std-1.16.1/src/Test.sol`).
- Bumped `flake.lock` so the dev shell carries a forge with the soldeer subcommand.
- Dropped `submodules: recursive` from `rainix.yaml`; added `forge soldeer install` before the test/static/legal tasks so `dependencies/` is populated.
- Added `.soldeerignore` so `test/`, `audit/`, `dependencies/`, `.github`, etc. are excluded from the published archive.
- Added `.github/workflows/publish-soldeer.yaml` (workflow_dispatch with version input) — uses the `rainlanguage` org `SOLDEER_API_TOKEN` secret.

## Test plan

- [x] Local: 25 suites, 262 tests, 0 failed.
- [ ] CI: rainix matrix (sol-test, sol-static, sol-legal) green on this branch.
- [ ] After merge: trigger `Publish to Soldeer` workflow with first version (e.g. `0.1.0`) so downstream `rain.string` and `rain.datacontract` migrations can consume it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
