### PR TITLE
docs: rewrite README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,48 +1,80 @@
-# LibBytes
+# rain.solmem
 
-Things we want to do carefully and efficiently with `bytes` in memory that
-Solidity doesn't give us native tools for.
+Solidity memory libraries — pointer arithmetic, byte-level copying, and dynamic
+arrays/matrices that don't go through Solidity's safety-checked allocator.
 
-## Dev stuff
+## Libraries
 
-### Local environment & CI
+| Library            | What it does                                                              |
+| ------------------ | ------------------------------------------------------------------------- |
+| `LibPointer`       | Raw memory pointer arithmetic, with explicit `Pointer` user-defined type. |
+| `LibMemCpy`        | Word-aligned and byte-aligned `memcpy` between memory pointers.           |
+| `LibBytes`         | In-place mutation, slicing, and pointer-level access for `bytes`.         |
+| `LibUint256Array`  | Dynamic `uint256[]` operations: extend, copy, dedup-sort, truncate.       |
+| `LibBytes32Array`  | Dynamic `bytes32[]` mirror of `LibUint256Array`.                          |
+| `LibUint256Matrix` | `uint256[][]` operations.                                                 |
+| `LibBytes32Matrix` | `bytes32[][]` operations.                                                 |
+| `LibStackPointer`  | Stack-style push/pop on a memory region accessed via `Pointer`.           |
+| `LibStackSentinel` | Sentinel-terminated stack walks for unknown-length data.                  |
 
-Uses nixos.
+These libraries assume the caller knows what they're doing with memory. Out-of-
+bounds access, double-frees, and aliasing are the caller's responsibility.
 
-Install `nix develop` - https://nixos.org/download.html.
+## Install
 
-Run `nix develop` in this repo to drop into the shell. Please ONLY use the nix
-version of `foundry` for development, to ensure versions are all compatible.
+Via [soldeer](https://soldeer.xyz) (in your foundry project's root):
 
-Read the `flake.nix` file to find some additional commands included for dev and
-CI usage.
-
-## Legal stuff
-
-Everything is under DecentraLicense 1.0 (DCL-1.0) which can be found in `LICENSES/`.
-
-This is basically `CAL-1.0` which is an open source license
-https://opensource.org/license/cal-1-0
-
-The non-legal summary of DCL-1.0 is that the source is open, as expected, but
-also user data in the systems that this code runs on must also be made available
-to those users as relevant, and that private keys remain private.
-
-Roughly it's "not your keys, not your coins" aware, as close as we could get in
-legalese.
-
-This is the default situation on permissionless blockchains, so shouldn't require
-any additional effort by dev-users to adhere to the license terms.
-
-This repo is REUSE 3.2 compliant https://reuse.software/spec-3.2/ and compatible
-with `reuse` tooling (also available in the nix shell here).
-
+```sh
+forge soldeer install rain-solmem~<version>
 ```
+
+Versioned remappings end up in `dependencies/rain-solmem-<version>/`. Add the
+remapping to `remappings.txt` or `foundry.toml`.
+
+## Develop
+
+This repo uses [nix](https://nixos.org/download.html) for its dev shell. The
+default shell is the slim Solidity-only `sol-shell` from
+[rainix](https://github.com/rainlanguage/rainix) — no rust, node, or chromium.
+
+```sh
+nix develop          # enter the shell
+forge soldeer install # install dependencies declared in foundry.toml
+forge test
+```
+
+Tasks exposed via the shell (delegate to rainix):
+
+- `rainix-sol-test` — `forge test`
+- `rainix-sol-static` — slither
+- `rainix-sol-legal` — `reuse lint`
+- `rainix-sol-artifacts` — `forge build`
+
+Use the nix-pinned `forge` for all development to keep versions consistent.
+
+## Publish
+
+Tag `v<x.y.z>` on `main`. The
+[`Publish to Soldeer`](.github/workflows/publish-soldeer.yaml) workflow runs
+`forge soldeer push rain-solmem~<x.y.z>` on every `v*` tag. The package name is
+derived from the repo name with `.` substituted for `-`.
+
+## License
+
+DecentraLicense 1.0 (DCL-1.0) — full text in
+[`LICENSES/`](LICENSES/LicenseRef-DCL-1.0.txt). Roughly `CAL-1.0`
+([opensource.org](https://opensource.org/license/cal-1-0)) plus user-data
+disclosure obligations consistent with permissionless-blockchain assumptions.
+"Not your keys, not your coins" aware, in legalese.
+
+This repo is [REUSE 3.2](https://reuse.software/spec-3.2/) compliant. Verify
+locally:
+
+```sh
 nix develop -c rainix-sol-legal
 ```
 
 ## Contributions
 
-Contributions are welcome **under the same license** as above.
-
-Contributors agree and warrant that their contributions are compliant.
+Welcome under the same license. Contributors warrant that their contributions
+are compliant.


### PR DESCRIPTION
Replaces the old LibBytes-only README with one that covers the full nine-library surface, soldeer install instructions, and the new sol-shell-based dev flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)