### PR TITLE
ci: switch publish-soldeer to rainix reusable

### DIFF
--- a/.github/workflows/publish-soldeer.yaml
+++ b/.github/workflows/publish-soldeer.yaml
@@ -5,30 +5,5 @@ on:
       - "v*"
 jobs:
   publish:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: nixbuild/nix-quick-install-action@v30
-        with:
-          nix_conf: |
-            keep-env-derivations = true
-            keep-outputs = true
-      - name: Restore and save Nix store
-        uses: nix-community/cache-nix-action@v6
-        with:
-          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-
-          gc-max-store-size-linux: 1G
-      - name: Push to Soldeer
-        env:
-          SOLDEER_API_TOKEN: ${{ secrets.SOLDEER_API_TOKEN }}
-        run: |
-          # Derive the soldeer package name from the GitHub repo name so
-          # this workflow can drop into any rain.* repo unchanged. Soldeer
-          # rejects `.` in package names, so rain.solmem -> rain-solmem.
-          PACKAGE="${GITHUB_REPOSITORY##*/}"
-          PACKAGE="${PACKAGE//./-}"
-          VERSION="${GITHUB_REF_NAME#v}"
-          nix develop -c forge soldeer push "${PACKAGE}~${VERSION}"
+    uses: rainlanguage/rainix/.github/workflows/publish-soldeer.yaml@main
+    secrets: inherit


### PR DESCRIPTION
Replaces the in-repo publish steps with a five-line wrapper that delegates to rainlanguage/rainix#136. Same behaviour; central source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)