### PR TITLE
ci: use rainix static-checks reusable

### DIFF
--- a/.github/workflows/rainix-sol-static.yaml
+++ b/.github/workflows/rainix-sol-static.yaml
@@ -1,0 +1,5 @@
+name: rainix-sol-static
+on: [push]
+jobs:
+  static:
+    uses: rainlanguage/rainix/.github/workflows/rainix-sol-static.yaml@main

--- a/.github/workflows/rainix.yaml
+++ b/.github/workflows/rainix.yaml
@@ -1,12 +1,11 @@
 name: Rainix CI
 on: [push]
-
 jobs:
   rainix:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        task: [rainix-sol-test, rainix-sol-static, rainix-sol-legal]
+        task: [rainix-sol-test, rainix-sol-legal]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     env:
@@ -15,7 +14,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
       - uses: nixbuild/nix-quick-install-action@v30
         with:
           nix_conf: |
@@ -32,7 +30,6 @@ jobs:
           # before trying to save a new cache
           # 1G = 1073741824
           gc-max-store-size-linux: 1G
-
       - run: nix develop -c forge soldeer install
       - name: Run ${{ matrix.task }}
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ docs
 
 # Soldeer
 /dependencies
+.pre-commit-config.yaml


### PR DESCRIPTION
Switches the static-checks job to a thin wrapper that delegates to the reusable workflow added in rainlanguage/rainix#137. Same coverage; central source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
