### PR TITLE
ci: use rainix legal-checks reusable

### DIFF
--- a/.github/workflows/rainix-sol-legal.yaml
+++ b/.github/workflows/rainix-sol-legal.yaml
@@ -1,0 +1,5 @@
+name: rainix-sol-legal
+on: [push]
+jobs:
+  legal:
+    uses: rainlanguage/rainix/.github/workflows/rainix-sol-legal.yaml@main

--- a/.github/workflows/rainix.yaml
+++ b/.github/workflows/rainix.yaml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        task: [rainix-sol-test, rainix-sol-legal]
+        task: [rainix-sol-test]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
Mirrors the static-checks rollout. Replaces the in-matrix legal job with a delegating wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)