### PR TITLE
test(bytes): mutation-validated coverage

### DIFF
--- a/test/src/lib/LibBytes.t.sol
+++ b/test/src/lib/LibBytes.t.sol
@@ -43,13 +43,71 @@ contract LibBytesTest is Test {
         assertEq(data, copy);
     }
 
-    function testEndPointers(uint8 length) public pure {
+    /// Assert every pointer of `data` against values derived from the layout of
+    /// a `bytes` in memory rather than from the implementation: a 32 byte length
+    /// prefix, then `length` bytes of data, then padding out to a whole number
+    /// of 32 byte words.
+    function checkPointers(bytes memory data, uint256 length) internal pure {
+        uint256 start = Pointer.unwrap(data.startPointer());
+
+        assertEq(data.length, length, "length");
+        assertEq(Pointer.unwrap(data.dataPointer()), start + 32, "dataPointer");
+        assertEq(Pointer.unwrap(data.endDataPointer()), start + 32 + length, "endDataPointer");
+
+        // Whole words needed to hold `length` bytes, rounded up.
+        uint256 words = length / 32;
+        if (length % 32 != 0) {
+            ++words;
+        }
+        assertEq(Pointer.unwrap(data.endAllocatedPointer()), start + 32 + (words * 32), "endAllocatedPointer");
+    }
+
+    /// The length domain here is deliberately wider than a single byte so that
+    /// pointer arithmetic that is only wrong past 0xff is caught.
+    function testEndPointers(uint16 length) public pure {
         bytes memory data = new bytes(length);
         assertEq(Pointer.unwrap(data.endAllocatedPointer()), Pointer.unwrap(LibPointer.allocatedMemoryPointer()));
-        assertEq(
-            Pointer.unwrap(data.endAllocatedPointer()) - Pointer.unwrap(data.endDataPointer()),
-            (0x20 - (length % 32)) % 0x20
-        );
-        assertEq(Pointer.unwrap(data.endDataPointer()) - Pointer.unwrap(data.dataPointer()), length);
+        checkPointers(data, length);
+    }
+
+    /// Deterministic coverage of the word alignment boundaries and of lengths
+    /// that a `uint8` bounded fuzz can never reach.
+    function testEndPointersExactLengths() public pure {
+        uint256[12] memory lengths = [uint256(0), 1, 31, 32, 33, 63, 64, 255, 256, 257, 1000, 1024];
+        for (uint256 i = 0; i < lengths.length; ++i) {
+            bytes memory data = new bytes(lengths[i]);
+            checkPointers(data, lengths[i]);
+        }
+    }
+
+    /// Truncation must set the length EXACTLY, including for lengths that do
+    /// not fit in a single byte, and must not disturb the retained data.
+    function testTruncateLargeExact() public pure {
+        bytes memory data = new bytes(1000);
+        for (uint256 i = 0; i < 1000; ++i) {
+            data[i] = bytes1(uint8((i % 251) + 1));
+        }
+
+        data.truncate(300);
+
+        assertEq(data.length, 300);
+        for (uint256 i = 0; i < 300; ++i) {
+            assertEq(uint8(data[i]), uint8((i % 251) + 1));
+        }
+        checkPointers(data, 300);
+    }
+
+    /// Truncating to exactly the current length is a no-op, NOT a revert.
+    function testTruncateToOwnLengthExact() public pure {
+        bytes memory data = hex"0102030405";
+        data.truncate(5);
+        assertEq(data, hex"0102030405");
+    }
+
+    /// Truncating to one byte longer than the current length reverts.
+    function testTruncateOneTooLongExact() public {
+        bytes memory data = hex"0102030405";
+        vm.expectRevert(abi.encodeWithSelector(TruncateError.selector, 5, 6));
+        this.truncateExternal(data, 6);
     }
 }


### PR DESCRIPTION
Mutation-validated coverage for `src/lib/LibBytes.sol`.

Baseline verified at 262 passing before any probe; 266 passing after.

## Method

Every behaviour in the unit — the truncate guard and its revert, the length
mstore, and the four pointer computations (start / data / endData /
endAllocated) including the length prefix, the word rounding and the alignment
mask — was broken one at a time and the whole suite re-run. 27 mutants total.

## Survivors found (real coverage gaps)

All three surviving mutants share one root cause: `testEndPointers` took a
`uint8` length, so no assertion in the suite ever reached a `bytes` longer than
255 bytes, and `testTruncateFuzz` did not reliably generate one either. A
mutation that is correct up to 0xff and wrong above it went unnoticed.

| behaviour | mutation | now killed by |
| --- | --- | --- |
| `endAllocatedPointer` word rounding | `if gt(mload(data), 0xff) { pointer := add(pointer, 0x20) }` | `testEndPointersExactLengths`, `testTruncateLargeExact`, `testEndPointers` |
| `endDataPointer` length prefix arithmetic | `if gt(mload(data), 0xff) { pointer := add(pointer, 1) }` | `testEndPointersExactLengths`, `testTruncateLargeExact`, `testEndPointers` |
| `truncate` length mstore | `if gt(length, 0xff) { mstore(data, sub(length, 1)) }` | `testTruncateLargeExact` |

## Behaviours already covered (mutants killed by existing tests, left as-is)

| behaviour | mutation | killed by |
| --- | --- | --- |
| truncate guard comparison | `<` -> `<=` | `testTruncateFuzz` |
| truncate guard direction | `<` -> `>` | `testTruncateError`, `testTruncateFuzz` |
| truncate guard off-by-one | `<` -> `+ 1 <` | `testTruncateError` |
| truncate guard removed | `if (false)` | `testTruncateError` |
| `TruncateError` argument order | args swapped | `testTruncateError` |
| truncate length write | mstore made a no-op | `testTruncateFuzz` |
| truncate length write | `mstore(data, add(length, 1))` | `testTruncateFuzz` |
| truncate preserves data | clobber first / last retained byte | `testCopyDirtyTargetFuzz` |
| `dataPointer` word offset | `0x20` -> `0x40`, `0x20` -> `0` | `testDataPointerFuzz` + 7 others |
| `dataPointer` zero-length case | special-cased to `data` | `testEndPointers`, `testCopySimple` |
| `startPointer` identity | `data` -> `add(data, 0x20)` | `testRoundBytesPointer` + 3 others |
| `endDataPointer` length prefix | `0x20` -> `0x00` | `testEndPointers` |
| `endDataPointer` uses length | `mload(data)` -> `0` | `testEndPointers` |
| `endDataPointer` off-by-one | `+ 1` | `testEndPointers` |
| `endDataPointer` zero-length case | special-cased to `data` | `testEndPointers` |
| `endAllocated` round-up addend | `0x1f` -> `0x20` / `0x1e` | `testEndPointers` |
| `endAllocated` alignment mask | `not(0x1f)` -> `not(0x0f)` / `not(0x3f)` | `testEndPointers` |
| `endAllocated` rounding removed | rounding dropped entirely | `testEndPointers` |
| `endAllocated` length prefix | `0x20` -> `0x40` | `testEndPointers` |
| `endAllocated` zero-length case | special-cased to `data` | `testEndPointers` |

## Changes

- `testEndPointers` widened from `uint8` to `uint16`, and its expected values
  re-derived from the memory layout of a `bytes` (32 byte length prefix, then
  the data, then padding to whole words) instead of restating the
  implementation's own `(0x20 - (length % 32)) % 0x20` rounding expression.
  Strengthened in place rather than duplicated.
- `testEndPointersExactLengths` — deterministic table over 0, 1, 31, 32, 33,
  63, 64, 255, 256, 257, 1000, 1024 so the alignment boundaries and the
  past-0xff lengths are covered without relying on the fuzzer.
- `testTruncateLargeExact` — truncates a 1000 byte array to exactly 300 and
  asserts every retained byte, so a truncation that is off by one only for
  large lengths cannot pass.
- `testTruncateToOwnLengthExact` / `testTruncateOneTooLongExact` — deterministic
  coverage of the revert boundary at `length == data.length` and
  `length == data.length + 1`, which previously depended on the fuzzer landing
  on the exact boundary.

No source changes. Bug candidates found during the adversarial pass are
reported separately and are deliberately not in this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for byte-array pointer calculations across boundary and exact-length scenarios.
  * Added validation for truncating large arrays while preserving retained data.
  * Confirmed truncation to the current length is a no-op.
  * Confirmed truncation beyond the current length correctly reverts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->