### PR TITLE
test(bytes32): mutation-validated coverage

### DIFF
--- a/test/src/lib/LibBytes32Array.allocation.t.sol
+++ b/test/src/lib/LibBytes32Array.allocation.t.sol
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+
+import {LibBytes32Array, Pointer} from "src/lib/LibBytes32Array.sol";
+import {LibPointer} from "src/lib/LibPointer.sol";
+
+/// The existing `unsafeExtend` tests assert the CONTENTS of the extended array
+/// against a reference implementation. Contents alone cannot see the allocator
+/// invariants the assembly is responsible for: extending is free to
+/// over-allocate, or to write past the free memory pointer it just set, without
+/// any content assertion noticing. These tests pin those invariants down.
+///
+/// Every one of these tests must read the free memory pointer IMMEDIATELY after
+/// the call under test. Assertions allocate, so any assertion made first moves
+/// the free memory pointer and destroys the measurement.
+contract LibBytes32ArrayAllocationTest is Test {
+    using LibBytes32Array for bytes32[];
+
+    /// Number of words of free memory poisoned above the free memory pointer.
+    uint256 internal constant POISON_WORDS = 8;
+
+    /// Poison `POISON_WORDS` words of FREE memory starting at the free memory
+    /// pointer with per-word recognisable sentinels. Returns the free memory
+    /// pointer as it stood before the call under test.
+    function _poisonFreeMemory() internal pure returns (uint256 fmpBefore) {
+        assembly ("memory-safe") {
+            fmpBefore := mload(0x40)
+            for { let i := 0 } lt(i, 8) { i := add(i, 1) } {
+                mstore(add(fmpBefore, mul(i, 0x20)), add(0xF00D0000, i))
+            }
+        }
+    }
+
+    /// Copy the poisoned region into `captured`, which the caller allocated
+    /// BEFORE poisoning so that it sits below the poisoned region and is itself
+    /// never disturbed. Copying must happen before any assertion runs.
+    function _capture(bytes32[POISON_WORDS] memory captured, uint256 fmpBefore) internal pure {
+        assembly ("memory-safe") {
+            for { let i := 0 } lt(i, 8) { i := add(i, 1) } {
+                mstore(add(captured, mul(i, 0x20)), mload(add(fmpBefore, mul(i, 0x20))))
+            }
+        }
+    }
+
+    /// Every poisoned word that lies at or above the FINAL free memory pointer
+    /// is still free memory and must therefore be untouched.
+    function _assertNothingWrittenPastFmp(bytes32[POISON_WORDS] memory captured, uint256 fmpBefore, uint256 fmpAfter)
+        internal
+        pure
+    {
+        for (uint256 i = 0; i < POISON_WORDS; i++) {
+            if (fmpBefore + i * 0x20 < fmpAfter) {
+                continue;
+            }
+            assertEq(captured[i], bytes32(uint256(0xF00D0000 + i)), "wrote past the free memory pointer");
+        }
+    }
+
+    /// On the inline path the free memory pointer must end up EXACTLY at the
+    /// end of the extended array. Over-allocating here is invisible to every
+    /// content assertion but wastes memory and breaks the "base is the last
+    /// allocation" precondition that the next inline extension relies on.
+    function testExtendInlineAllocatesExactly() public pure {
+        bytes32[] memory extend = new bytes32[](2);
+        extend[0] = bytes32(uint256(0x44));
+        extend[1] = bytes32(uint256(0x55));
+
+        // Allocated last, so `base` is the most recent allocation and the
+        // inline branch is taken.
+        bytes32[] memory base = new bytes32[](3);
+        base[0] = bytes32(uint256(0x11));
+        base[1] = bytes32(uint256(0x22));
+        base[2] = bytes32(uint256(0x33));
+
+        bytes32[] memory extended = LibBytes32Array.unsafeExtend(base, extend);
+        uint256 fmpAfter = uint256(Pointer.unwrap(LibPointer.allocatedMemoryPointer()));
+        uint256 endOfExtended = uint256(Pointer.unwrap(extended.endPointer()));
+
+        assertEq(extended.length, 5, "length");
+        assertEq(extended[0], bytes32(uint256(0x11)));
+        assertEq(extended[1], bytes32(uint256(0x22)));
+        assertEq(extended[2], bytes32(uint256(0x33)));
+        assertEq(extended[3], bytes32(uint256(0x44)));
+        assertEq(extended[4], bytes32(uint256(0x55)));
+        assertEq(fmpAfter, endOfExtended, "fmp must sit exactly at the end of the extended array");
+    }
+
+    /// Same invariant on the allocate-and-copy path, reached when the base
+    /// array is not the most recent allocation.
+    function testExtendAllocateAllocatesExactly() public pure {
+        bytes32[] memory base = new bytes32[](3);
+        base[0] = bytes32(uint256(0x11));
+        base[1] = bytes32(uint256(0x22));
+        base[2] = bytes32(uint256(0x33));
+
+        // Allocated after `base`, so `base` is no longer the last allocation.
+        bytes32[] memory extend = new bytes32[](2);
+        extend[0] = bytes32(uint256(0x44));
+        extend[1] = bytes32(uint256(0x55));
+
+        bytes32[] memory extended = LibBytes32Array.unsafeExtend(base, extend);
+        uint256 fmpAfter = uint256(Pointer.unwrap(LibPointer.allocatedMemoryPointer()));
+        uint256 endOfExtended = uint256(Pointer.unwrap(extended.endPointer()));
+
+        assertEq(extended.length, 5, "length");
+        assertEq(extended[0], bytes32(uint256(0x11)));
+        assertEq(extended[4], bytes32(uint256(0x55)));
+        assertEq(fmpAfter, endOfExtended, "fmp must sit exactly at the end of the extended array");
+    }
+
+    /// The inline path must not write above the free memory pointer it sets.
+    /// A copy that runs one word long lands on memory the allocator still
+    /// considers free, which the next allocation then hands out to someone else.
+    function testExtendInlineDoesNotWritePastFreeMemoryPointer() public pure {
+        bytes32[POISON_WORDS] memory captured;
+
+        bytes32[] memory extend = new bytes32[](1);
+        extend[0] = bytes32(uint256(0x44));
+
+        bytes32[] memory base = new bytes32[](2);
+        base[0] = bytes32(uint256(0x11));
+        base[1] = bytes32(uint256(0x22));
+
+        uint256 fmpBefore = _poisonFreeMemory();
+        bytes32[] memory extended = LibBytes32Array.unsafeExtend(base, extend);
+        uint256 fmpAfter;
+        assembly ("memory-safe") {
+            fmpAfter := mload(0x40)
+        }
+        _capture(captured, fmpBefore);
+
+        assertEq(extended.length, 3, "length");
+        assertEq(extended[2], bytes32(uint256(0x44)));
+        _assertNothingWrittenPastFmp(captured, fmpBefore, fmpAfter);
+    }
+
+    /// Same invariant on the allocate-and-copy path. An empty extend array is
+    /// used so that the extension copy cannot mask an over-long base copy.
+    function testExtendAllocateDoesNotWritePastFreeMemoryPointer() public pure {
+        bytes32[POISON_WORDS] memory captured;
+
+        bytes32[] memory base = new bytes32[](2);
+        base[0] = bytes32(uint256(0x11));
+        base[1] = bytes32(uint256(0x22));
+
+        // Allocated after `base`, forcing the allocate-and-copy branch.
+        bytes32[] memory extend = new bytes32[](0);
+
+        uint256 fmpBefore = _poisonFreeMemory();
+        bytes32[] memory extended = LibBytes32Array.unsafeExtend(base, extend);
+        uint256 fmpAfter;
+        assembly ("memory-safe") {
+            fmpAfter := mload(0x40)
+        }
+        _capture(captured, fmpBefore);
+
+        assertEq(extended.length, 2, "length");
+        assertEq(extended[0], bytes32(uint256(0x11)));
+        assertEq(extended[1], bytes32(uint256(0x22)));
+        _assertNothingWrittenPastFmp(captured, fmpBefore, fmpAfter);
+    }
+}

--- a/test/src/lib/LibBytes32Array.reverse.t.sol
+++ b/test/src/lib/LibBytes32Array.reverse.t.sol
@@ -3,7 +3,8 @@
 pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
-import {LibBytes32Array} from "src/lib/LibBytes32Array.sol";
+import {LibBytes32Array, Pointer} from "src/lib/LibBytes32Array.sol";
+import {LibPointer} from "src/lib/LibPointer.sol";
 import {LibBytes32ArraySlow} from "test/lib/LibBytes32ArraySlow.sol";
 
 contract LibBytes32ArrayReverseTest is Test {
@@ -14,7 +15,14 @@ contract LibBytes32ArrayReverseTest is Test {
         for (uint256 i = 0; i < a.length; i++) {
             b[i] = a[i];
         }
+
+        // reverse is documented to mutate in place, so it must not move the
+        // free memory pointer at all. Read the pointer immediately either side
+        // of the call under test, as assertions themselves allocate.
+        Pointer allocatedBefore = LibPointer.allocatedMemoryPointer();
         LibBytes32Array.reverse(a);
+        Pointer allocatedAfter = LibPointer.allocatedMemoryPointer();
+        assertEq(Pointer.unwrap(allocatedBefore), Pointer.unwrap(allocatedAfter), "reverse allocated");
 
         assertEq(a, LibBytes32ArraySlow.reverseSlow(b));
     }

--- a/test/src/lib/LibBytes32Array.truncate.t.sol
+++ b/test/src/lib/LibBytes32Array.truncate.t.sol
@@ -3,7 +3,8 @@
 pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
-import {LibBytes32Array} from "src/lib/LibBytes32Array.sol";
+import {LibBytes32Array, Pointer} from "src/lib/LibBytes32Array.sol";
+import {LibPointer} from "src/lib/LibPointer.sol";
 import {OutOfBoundsTruncate} from "src/error/ErrUint256Array.sol";
 import {LibBytes32ArraySlow} from "test/lib/LibBytes32ArraySlow.sol";
 
@@ -21,7 +22,14 @@ contract LibBytes32ArrayTruncateTest is Test {
         }
         assertEq(a, b);
 
+        // truncate is documented to mutate in place with "no new allocation or
+        // copying of data", so it must not move the free memory pointer. Read
+        // the pointer immediately either side of the call under test, as
+        // assertions themselves allocate.
+        Pointer allocatedBefore = LibPointer.allocatedMemoryPointer();
         LibBytes32Array.truncate(a, newLength);
+        Pointer allocatedAfter = LibPointer.allocatedMemoryPointer();
+        assertEq(Pointer.unwrap(allocatedBefore), Pointer.unwrap(allocatedAfter), "truncate allocated");
 
         b = LibBytes32ArraySlow.truncateSlow(b, newLength);
         assertEq(a, b);

--- a/test/src/lib/LibBytes32Matrix.allocation.t.sol
+++ b/test/src/lib/LibBytes32Matrix.allocation.t.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+
+import {LibBytes32Array} from "src/lib/LibBytes32Array.sol";
+import {LibBytes32Matrix, LibPointer, Pointer} from "src/lib/LibBytes32Matrix.sol";
+
+/// The existing `flatten` tests assert the CONTENTS of the flattened array.
+/// `flatten` also performs an allocation, and an over-allocating `flatten`
+/// passes every content assertion while leaving the free memory pointer beyond
+/// the end of the array it returned. `matrixFrom` and `arrayFrom` are already
+/// pinned to `allocatedMemoryPointer()`; `flatten` was not.
+contract LibBytes32MatrixAllocationTest is Test {
+    using LibBytes32Array for bytes32[];
+    using LibBytes32Matrix for bytes32[][];
+
+    /// forge-config: default.fuzz.runs = 100
+    function testFlattenAllocatesExactly(bytes32[][] memory matrix) external pure {
+        bytes32[] memory flattened = matrix.flatten();
+
+        assertEq(
+            Pointer.unwrap(LibPointer.allocatedMemoryPointer()),
+            Pointer.unwrap(flattened.endPointer()),
+            "fmp must sit exactly at the end of the flattened array"
+        );
+    }
+
+    /// Concrete non-fuzzed case: a matrix of two non-empty arrays.
+    function testFlattenAllocatesExactlyConcrete() external pure {
+        bytes32[][] memory matrix = new bytes32[][](2);
+        matrix[0] = LibBytes32Array.arrayFrom(bytes32(uint256(0x81)), bytes32(uint256(0x82)));
+        matrix[1] = LibBytes32Array.arrayFrom(bytes32(uint256(0x83)));
+
+        bytes32[] memory flattened = matrix.flatten();
+        // Read the free memory pointer BEFORE any assertion, because assertions
+        // allocate and would move it.
+        uint256 fmpAfter = uint256(Pointer.unwrap(LibPointer.allocatedMemoryPointer()));
+        uint256 endOfFlattened = uint256(Pointer.unwrap(flattened.endPointer()));
+
+        assertEq(flattened.length, 3, "length");
+        assertEq(flattened[0], bytes32(uint256(0x81)));
+        assertEq(flattened[1], bytes32(uint256(0x82)));
+        assertEq(flattened[2], bytes32(uint256(0x83)));
+        assertEq(fmpAfter, endOfFlattened, "fmp must sit exactly at the end of the flattened array");
+    }
+
+    /// An empty matrix must still allocate exactly the one length word.
+    function testFlattenEmptyAllocatesLengthWordOnly() external pure {
+        bytes32[][] memory matrix = new bytes32[][](0);
+
+        uint256 fmpBefore = uint256(Pointer.unwrap(LibPointer.allocatedMemoryPointer()));
+        bytes32[] memory flattened = matrix.flatten();
+        uint256 fmpAfter = uint256(Pointer.unwrap(LibPointer.allocatedMemoryPointer()));
+
+        assertEq(flattened.length, 0, "length");
+        assertEq(fmpAfter - fmpBefore, 0x20, "exactly one length word allocated");
+    }
+}

--- a/test/src/lib/LibBytes32Matrix.itemCount.t.sol
+++ b/test/src/lib/LibBytes32Matrix.itemCount.t.sol
@@ -4,6 +4,7 @@ pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibBytes32Matrix} from "src/lib/LibBytes32Matrix.sol";
+import {LibPointer, Pointer} from "src/lib/LibPointer.sol";
 import {LibBytes32MatrixSlow} from "test/lib/LibBytes32MatrixSlow.sol";
 
 contract LibBytes32MatrixItemCountTest is Test {
@@ -12,6 +13,14 @@ contract LibBytes32MatrixItemCountTest is Test {
 
     /// forge-config: default.fuzz.runs = 100
     function testItemCountReference(bytes32[][] memory matrix) external pure {
-        assertEq(matrix.itemCount(), matrix.itemCountSlow());
+        // itemCount only reads the matrix, so it must not move the free memory
+        // pointer. Read the pointer immediately either side of the call under
+        // test, as assertions themselves allocate.
+        Pointer allocatedBefore = LibPointer.allocatedMemoryPointer();
+        uint256 count = matrix.itemCount();
+        Pointer allocatedAfter = LibPointer.allocatedMemoryPointer();
+        assertEq(Pointer.unwrap(allocatedBefore), Pointer.unwrap(allocatedAfter), "itemCount allocated");
+
+        assertEq(count, matrix.itemCountSlow());
     }
 }


### PR DESCRIPTION
Adversarial mutation testing pass over `src/lib/LibBytes32Array.sol` and
`src/lib/LibBytes32Matrix.sol`.

Baseline verified at 262 passing before any probe. 85 targeted mutations were
applied one at a time, each rebuilt and run against the suite, each reverted
via git afterwards. Two semantically-neutral mutations were used as negative
controls to prove the harness can report a survivor at all — both survived, as
they must.

80 of the 85 mutants were killed by the existing suite, which is a genuinely
strong result: every length prefix, element offset, pointer computation, loop
bound, branch and revert path in both libraries is already covered.

The 5 remaining probes exposed one real blind spot, in two shapes. Both
`unsafeExtend` and `flatten` are asserted only against reference
implementations, i.e. on the CONTENTS of the array they return. Contents cannot
observe what those functions do to the allocator. A version that over-allocates
the free memory pointer, or that copies one word too many past it, returns
byte-identical contents and passes every existing assertion.

`arrayFrom` and `matrixFrom` were already pinned to
`LibPointer.allocatedMemoryPointer()`; `unsafeExtend` and `flatten` were not.
This PR closes that gap.

## behaviour -> mutation -> killing test

| behaviour | mutation | killing test |
| --- | --- | --- |
| `unsafeExtend` inline path allocates exactly | `outputEnd` computed with `0x40` instead of `0x20` (over-allocate one word) | `testExtendInlineAllocatesExactly`, `testExtendAllocateAllocatesExactly` |
| `flatten` allocates exactly | fmp set with `0x40` instead of `0x20` (over-allocate one word) | `testFlattenAllocatesExactly`, `testFlattenAllocatesExactlyConcrete`, `testFlattenEmptyAllocatesLengthWordOnly` |
| `unsafeExtend` inline path writes nothing above the fmp | extension `mcopy` length `+ 0x20` | `testExtendInlineDoesNotWritePastFreeMemoryPointer` |
| `unsafeExtend` allocate-and-copy path writes nothing above the fmp | base `mcopy` length `+ 0x20` | `testExtendAllocateDoesNotWritePastFreeMemoryPointer` |

Each new test was verified in both directions: it passes on unmodified `src`
and fails under its target mutation.

The "writes nothing above the fmp" tests work by poisoning eight words of free
memory above the free memory pointer with recognisable per-word sentinels,
running the call, then copying the region into a buffer allocated beforehand
and checking that every word still at or above the FINAL free memory pointer
is intact. The copy has to happen before any assertion, because assertions
allocate.

That same subtlety is worth flagging for reviewers: an earlier draft of these
tests read `allocatedMemoryPointer()` after asserting contents, and the
assertions themselves had already moved the free memory pointer by `0x40`. All
free-memory-pointer reads here happen immediately after the call under test.

Suite goes from 262 to 269 passing. No source changes.


---

## second pass (commit `f5f7538`)

An independent re-run of the campaign from a fresh clone reproduced the two
findings above and turned up a third, adjacent one that the first pass missed.

`reverse`, `truncate` and `itemCount` are the mirror image of the case above.
`unsafeExtend`/`flatten` were unpinned because they allocate and nothing checked
how much. These three are unpinned because they are documented NOT to allocate
at all — `reverse` "MUTATES the array in place", `truncate` promises "no new
allocation or copying of data either", `itemCount` only reads — and nothing
checked that either. A mutant that bumps the free memory pointer by one word
inside any of the three survives the entire suite untouched.

| behaviour | mutation | killing test |
| --- | --- | --- |
| `reverse` does not allocate | `mstore(0x40, add(mload(0x40), 0x20))` at the top of the loop setup | `testReverse` |
| `truncate` does not allocate | `mstore(0x40, add(mload(0x40), 0x20))` after the length store | `testTruncate` |
| `itemCount` does not allocate | `mstore(0x40, add(mload(0x40), 0x20))` after the loop bound | `testItemCountReference` |

Verified in both directions: each of the three mutants survives on `67808c4`
and is killed on `f5f7538`; the suite is green on unmodified `src`.

Suite goes from 269 to 269 passing — these strengthen three existing reference
tests in place rather than adding parallel ones.

## found but NOT addressed here: `unsafeExtend` self-aliasing

The second pass also surfaced a likely source defect, deliberately left out of
this PR since this PR makes no source changes.

The inline branch of `unsafeExtend` does:

```solidity
mstore(base, totalLength)
mstore(0x40, outputEnd)
mcopy(baseEnd, add(extend, 0x20), mul(mload(extend), 0x20))
```

`mload(extend)` is read AFTER `mstore(base, totalLength)`. When a caller passes
the same array as both arguments — `unsafeExtend(a, a)`, which the NatSpec does
not forbid — `extend` and `base` are the same pointer, so `mload(extend)` has
already been clobbered with `totalLength` (twice the real length) and the copy
moves twice as many words as it should. The surplus words land above the free
memory pointer the function just set, inside a block annotated
`("memory-safe")`.

The returned CONTENTS are still correct (the overlapping copy happens to land
the first `n` words where they belong), so no content-based test can see this.
A repro against a poisoned free-memory region shows the word at the new free
memory pointer changing from sentinel `0xD00D0003` to `0xD00D0002`.

Two further notes on it: the allocate-and-copy branch handles the same call
correctly, because `base` is copied away before the inline branch runs — so the
memory-safety outcome depends on the caller's memory layout. And reordering the
inline branch to do the `mcopy` before `mstore(base, totalLength)` is a mutation
that SURVIVES the suite even after this PR, which is exactly the signature of
the behaviour being unconstrained. Reporting rather than fixing, since the fix
is a source change and this repo's NatSpec may intend aliasing to be the
caller's problem.
