### PR TITLE
test(pointer-core): mutation-validated coverage

### DIFF
--- a/test/src/lib/LibMemCpy.Bytes.t.sol
+++ b/test/src/lib/LibMemCpy.Bytes.t.sol
@@ -59,6 +59,54 @@ contract LibMemCpyBytesTest is Test {
         assertEq(remainder, remainderCopy);
     }
 
+    /// The copy MUST move data from source into target, and MUST NOT move data
+    /// from target into source. Both buffers hold distinct non-zero patterns so
+    /// that a reversed copy is observable in both directions.
+    function testCopyBytesDirection() public pure {
+        bytes memory source = hex"aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899";
+        bytes memory target = new bytes(32);
+        for (uint256 i = 0; i < 32; i++) {
+            target[i] = 0x11;
+        }
+
+        LibMemCpy.unsafeCopyBytesTo(source.dataPointer(), target.dataPointer(), 32);
+
+        // Target receives the source bytes.
+        assertEq(target, hex"aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899");
+        // Source is left completely untouched.
+        assertEq(source, hex"aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899");
+    }
+
+    /// `mcopy` has memmove semantics, so a copy into an overlapping region at a
+    /// HIGHER address MUST read the original source bytes, not bytes that the
+    /// copy itself has already written.
+    function testCopyBytesOverlapForward() public pure {
+        bytes memory buffer =
+            hex"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f40";
+        assertEq(buffer.length, 64);
+
+        // Copy buffer[0:32] over buffer[16:48]. Source and target overlap by 16
+        // bytes with the target above the source.
+        LibMemCpy.unsafeCopyBytesTo(buffer.dataPointer(), buffer.dataPointer().unsafeAddBytes(16), 32);
+
+        assertEq(
+            buffer,
+            hex"0102030405060708090a0b0c0d0e0f100102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f203132333435363738393a3b3c3d3e3f40"
+        );
+    }
+
+    /// Overlapping copy into a LOWER address must also preserve the original
+    /// source bytes.
+    function testCopyBytesOverlapBackward() public pure {
+        bytes memory buffer = hex"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+        assertEq(buffer.length, 32);
+
+        // Copy buffer[8:24] over buffer[0:16].
+        LibMemCpy.unsafeCopyBytesTo(buffer.dataPointer().unsafeAddBytes(8), buffer.dataPointer(), 16);
+
+        assertEq(buffer, hex"08090a0b0c0d0e0f1011121314151617101112131415161718191a1b1c1d1e1f");
+    }
+
     function testCopyGas0() public pure {
         bytes memory a = hex"";
         LibMemCpy.unsafeCopyBytesTo(a.dataPointer(), LibPointer.allocatedMemoryPointer(), a.length);

--- a/test/src/lib/LibMemCpy.Words.t.sol
+++ b/test/src/lib/LibMemCpy.Words.t.sol
@@ -50,6 +50,78 @@ contract LibMemCpyWordsTest is Test {
         testCopyFuzz(source, type(uint256).max);
     }
 
+    /// The copy MUST move words from source into target, and MUST NOT move
+    /// words from target into source. Both arrays hold distinct non-zero values
+    /// so that a reversed copy is observable in both directions.
+    function testCopyWordsDirection() public pure {
+        uint256[] memory source = new uint256[](3);
+        source[0] = 7;
+        source[1] = 8;
+        source[2] = 9;
+
+        uint256[] memory target = new uint256[](3);
+        target[0] = 111;
+        target[1] = 222;
+        target[2] = 333;
+
+        LibMemCpy.unsafeCopyWordsTo(source.dataPointer(), target.dataPointer(), 3);
+
+        assertEq(target[0], 7);
+        assertEq(target[1], 8);
+        assertEq(target[2], 9);
+
+        // Source is left completely untouched.
+        assertEq(source[0], 7);
+        assertEq(source[1], 8);
+        assertEq(source[2], 9);
+    }
+
+    /// `mcopy` has memmove semantics, so a copy into an overlapping region at a
+    /// HIGHER address MUST read the original source words, not words that the
+    /// copy itself has already written.
+    function testCopyWordsOverlapForward() public pure {
+        uint256[] memory buffer = new uint256[](6);
+        buffer[0] = 1;
+        buffer[1] = 2;
+        buffer[2] = 3;
+        buffer[3] = 4;
+        buffer[4] = 5;
+        buffer[5] = 6;
+
+        // Copy buffer[0:4] over buffer[2:6]. Source and target overlap by two
+        // words with the target above the source.
+        LibMemCpy.unsafeCopyWordsTo(buffer.dataPointer(), buffer.dataPointer().unsafeAddWords(2), 4);
+
+        assertEq(buffer[0], 1);
+        assertEq(buffer[1], 2);
+        assertEq(buffer[2], 1);
+        assertEq(buffer[3], 2);
+        assertEq(buffer[4], 3);
+        assertEq(buffer[5], 4);
+    }
+
+    /// Overlapping copy into a LOWER address must also preserve the original
+    /// source words.
+    function testCopyWordsOverlapBackward() public pure {
+        uint256[] memory buffer = new uint256[](6);
+        buffer[0] = 1;
+        buffer[1] = 2;
+        buffer[2] = 3;
+        buffer[3] = 4;
+        buffer[4] = 5;
+        buffer[5] = 6;
+
+        // Copy buffer[2:6] over buffer[0:4].
+        LibMemCpy.unsafeCopyWordsTo(buffer.dataPointer().unsafeAddWords(2), buffer.dataPointer(), 4);
+
+        assertEq(buffer[0], 3);
+        assertEq(buffer[1], 4);
+        assertEq(buffer[2], 5);
+        assertEq(buffer[3], 6);
+        assertEq(buffer[4], 5);
+        assertEq(buffer[5], 6);
+    }
+
     // Uses somewhat circular logic to test that existing data in target cannot
     // corrupt copying from source somehow.
     function testCopyDirtyTargetFuzz(uint256[] memory source, uint256[] memory target) public pure {


### PR DESCRIPTION
Adversarial mutation testing pass over `src/lib/LibPointer.sol` and `src/lib/LibMemCpy.sol`.

Baseline verified at 262 passing before any probe. 20 targeted mutations applied one at a time, each rebuilt and run against the whole suite, restored via git after every probe. 16 were killed by existing tests. 4 survived; this PR closes those gaps. Suite is now 268 passing.

## Surviving mutants -> new tests

| behaviour | mutation | killing test |
| --- | --- | --- |
| `unsafeCopyBytesTo` copies source INTO target (argument order) | `mcopy(targetCursor, sourceCursor, length)` -> `mcopy(sourceCursor, targetCursor, length)` | `testCopyBytesDirection` |
| `unsafeCopyBytesTo` has memmove semantics for target above an overlapping source | `mcopy` -> naive ascending byte loop | `testCopyBytesOverlapForward` |
| `unsafeCopyWordsTo` copies source INTO target (argument order) | `mcopy(target, source, mul(length, 0x20))` -> `mcopy(source, target, mul(length, 0x20))` | `testCopyWordsDirection` |
| `unsafeCopyWordsTo` has memmove semantics for target above an overlapping source | `mcopy` -> naive ascending word loop | `testCopyWordsOverlapForward` |

The direction mutants survived because every existing copy test allocates its target with `new bytes(n)` / `new uint256[](n)`, so the target starts zeroed. Reversing the copy zeroes the source and leaves the target zeroed, and `assertEq(source, target)` still holds. The new direction tests give source and target distinct non-zero patterns and additionally assert the source is unmodified.

`testCopyBytesOverlapBackward` and `testCopyWordsOverlapBackward` are added alongside to pin the target-below-source overlap case, which no mutation reached but which was equally unasserted.

## Behaviours confirmed already covered (mutant killed, no new test)

| unit | behaviour | mutation | killed by |
| --- | --- | --- | --- |
| `LibPointer.unsafeAsBytes` | identity cast | `data := pointer` -> `add(pointer, 0x20)` | `testUnsafeAsBytesRound`, `testUnsafeAsBytesRoundBytes` |
| `LibPointer.unsafeAddBytes` | direction | `add` -> `sub` | `testUnsafeAddBytes` |
| `LibPointer.unsafeAddBytes` | offset applied | `add(pointer, length)` -> `add(pointer, 0)` | `testUnsafeAddBytes` |
| `LibPointer.unsafeAddWord` | word size | `0x20` -> `0x21` | `testUnsafeAddWord`, `testUnsafePeek` |
| `LibPointer.unsafeAddWords` | word scale | `mul(0x20, words)` -> `mul(0x21, words)` | `testUnsafeAddWords`, `testUnsafePeek2` |
| `LibPointer.unsafeAddWords` | scaling happens at all | `mul(0x20, words)` -> `words` | `testUnsafeAddWords`, `testUnsafePeek2` |
| `LibPointer.unsafeSubWord` | word size | `0x20` -> `0x21` | `testUnsafeSubWord`, `testUnsafeToIndexNegative` |
| `LibPointer.unsafeSubWords` | word scale | `mul(0x20, words)` -> `mul(0x21, words)` | `testUnsafeSubWords`, `testConsumeSentinelTuplesMultiSize` |
| `LibPointer.unsafeSubWords` | scaling happens at all | `mul(0x20, words)` -> `words` | `testUnsafeSubWords`, `testConsumeSentinelTuplesMultiSize` |
| `LibPointer.unsafeReadWord` | reads at the pointer | `mload(pointer)` -> `mload(add(pointer, 0x20))` | `testReadWriteRound`, `testUnsafePush` |
| `LibPointer.unsafeWriteWord` | writes at the pointer | `mstore(pointer, ...)` -> `mstore(add(pointer, 0x20), ...)` | `testReadWriteRound`, `testUnsafePop` |
| `LibPointer.unsafeWriteWord` | writes a full word | `mstore` -> `mstore8` | `testReadWriteRound`, `testUnsafePeek` |
| `LibPointer.allocatedMemoryPointer` | reads the free memory pointer slot | `mload(0x40)` -> `mload(0x60)` | 30 tests incl. `testAllocatedMemoryPointer` |
| `LibPointer.allocatedMemoryPointer` | dereferences the slot | `mload(0x40)` -> `0x40` | 30 tests incl. `testAllocatedMemoryPointer` |
| `LibMemCpy.unsafeCopyBytesTo` | exact byte count | `length` -> `add(length, 1)` | `testCopyFuzz` and siblings |
| `LibMemCpy.unsafeCopyBytesTo` | zero length writes nothing | `length` -> `add(length, iszero(length))` | `testCopyMaxSuffixFuzz` |
| `LibMemCpy.unsafeCopyBytesTo` | length is bytes not words | `length` -> `mul(length, 0x20)` | `testCopyFuzz` and siblings |
| `LibMemCpy.unsafeCopyWordsTo` | word scale | `mul(length, 0x20)` -> `mul(length, 0x21)` | `testCopyFuzz` and siblings |
| `LibMemCpy.unsafeCopyWordsTo` | length is words not bytes | `mul(length, 0x20)` -> `length` | `testCopyFuzz` and siblings |
| `LibMemCpy.unsafeCopyWordsTo` | zero length writes nothing | spurious one-word copy when `length` is 0 | `testCopyFuzz`, `testCopyMaxSuffixFuzz` |

No source file is modified by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for byte and word memory-copy operations.
  * Added checks confirming source data remains unchanged after copying.
  * Added overlap scenarios in both directions to verify safe, memmove-like behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->