### PR TITLE
test(stack-s3): mutation-validated coverage

### DIFF
--- a/test/src/lib/LibStackPointer.toIndexSigned.t.sol
+++ b/test/src/lib/LibStackPointer.toIndexSigned.t.sol
@@ -50,6 +50,23 @@ contract LibStackPointerToIndexSignedTest is Test {
         assertEq(lower.toIndexSigned(upper), -int256(lowerIndex - upperIndex));
     }
 
+    /// Equal pointers are exactly zero words apart. This pins the boundary of
+    /// the distance ternary, where `upper == lower`.
+    function testToIndexSignedEqualPointers() public pure {
+        assertEq(LibStackPointer.toIndexSigned(Pointer.wrap(0x80), Pointer.wrap(0x80)), 0);
+        assertEq(LibStackPointer.toIndexSigned(Pointer.wrap(0), Pointer.wrap(0)), 0);
+        assertEq(LibStackPointer.toIndexSigned(Pointer.wrap(0x20), Pointer.wrap(0x20)), 0);
+    }
+
+    /// Exact word distances immediately either side of the equality boundary,
+    /// and further out, in both directions.
+    function testToIndexSignedExactValues() public pure {
+        assertEq(LibStackPointer.toIndexSigned(Pointer.wrap(0x80), Pointer.wrap(0xa0)), 1);
+        assertEq(LibStackPointer.toIndexSigned(Pointer.wrap(0xa0), Pointer.wrap(0x80)), -1);
+        assertEq(LibStackPointer.toIndexSigned(Pointer.wrap(0x80), Pointer.wrap(0x100)), 4);
+        assertEq(LibStackPointer.toIndexSigned(Pointer.wrap(0x100), Pointer.wrap(0x80)), -4);
+    }
+
     /// Test that unaligned pointers throw.
     function testUnsafeToIndexUnalignedLower(Pointer lower, Pointer upper) public {
         uint256 difference = Pointer.unwrap(upper) >= Pointer.unwrap(lower)


### PR DESCRIPTION
Adversarial mutation pass over `LibStackPointer.toIndexSigned`, batch `s3`.

Baseline verified at 262 passed / 0 failed before any probe. A semantically
neutral negative control (reordering the two independent `mload`s in
`unsafePeek2`) correctly SURVIVED, proving the harness can report a survivor.

Suite is green at 264 (262 + 2 added).

## Behaviour -> mutation -> killing test

| # | Behaviour | Mutation | Outcome |
|---|---|---|---|
| P13 | distance ternary `>=` boundary (`upper == lower`) | `>=` -> `>` | SURVIVED - equivalent mutant, see below |
| P14 | alignment modulus `0x20` | `distance % 0x20` -> `% 0x40` | KILLED by `testUnsafeToIndexPositive` / `testUnsafeToIndexNegative` |
| P15 | alignment revert removed entirely | delete the `if (...) revert UnalignedStackPointer` block | KILLED by `testUnsafeToIndexUnalignedLower` |
| P16 | upper/lower operand order (sign of result) | swap operands in the final subtraction | KILLED by `testUnsafeToIndexPositive` / `testUnsafeToIndexNegative`, and now also by the added `testToIndexSignedExactValues` |
| P17 | divisor `0x20` in the final subtraction | `/ 0x20` -> `/ 0x40` | KILLED by `testUnsafeToIndexPositive` / `testUnsafeToIndexNegative`, and now also by the added `testToIndexSignedExactValues` |

## P13 is an equivalent mutant, not a coverage gap

`>=` and `>` differ only when `upper == lower`, and at that point both
branches compute the same value: `upper - lower == 0` and
`lower - upper == 0`. No test can distinguish them, so no test in this PR
claims to kill P13. This was confirmed empirically, not just by reasoning:
with the added tests present the P13 mutant still reports 264 passed / 0
failed.

The added `testToIndexSignedEqualPointers` pins the `upper == lower`
boundary at an exact value (`0`) as genuine coverage, and
`testToIndexSignedExactValues` pins exact word distances either side of it
(`+1`, `-1`, `+4`, `-4`). Existing coverage for this function was fuzz-only
with expectations recomputed from the same `/ 0x20` expression as the
implementation; these are deterministic literal-valued anchors.

Bug repros are deliberately excluded from this PR.