### PR TITLE
test(stack-s2): mutation-validated coverage

### DIFF
--- a/test/src/lib/LibStackPointer.t.sol
+++ b/test/src/lib/LibStackPointer.t.sol
@@ -114,4 +114,33 @@ contract LibStackPointerTest is Test {
         // array will be mutated due to the unsafety of the list.
         assertEq(uint256(array[array.length - length - 1]), length);
     }
+
+    /// `unsafeList` builds the array IN PLACE over the stack memory it was
+    /// handed. It MUST NOT allocate, and the returned `tail` MUST alias the
+    /// source memory rather than being a copy of it.
+    function testUnsafeListAliasesSourceWithoutAllocating(bytes32[] memory array, uint8 length, bytes32 poke)
+        public
+        pure
+    {
+        vm.assume(length < array.length);
+        Pointer pointer = array.endPointer();
+
+        Pointer allocatedBefore = LibPointer.allocatedMemoryPointer();
+        (, bytes32[] memory tail) = pointer.unsafeList(length);
+        Pointer allocatedAfter = LibPointer.allocatedMemoryPointer();
+
+        // "without allocating new memory" - the free memory pointer is untouched.
+        assertEq(Pointer.unwrap(allocatedBefore), Pointer.unwrap(allocatedAfter));
+
+        // The tail header sits exactly `length + 1` words below the stack top,
+        // i.e. inside the source array, not in freshly allocated memory.
+        assertEq(Pointer.unwrap(tail.startPointer()), Pointer.unwrap(pointer) - 0x20 * (uint256(length) + 1));
+
+        // Aliasing is bidirectional: writing through `tail` writes into `array`.
+        if (length > 0) {
+            tail[0] = poke;
+            assertEq(array[array.length - length], poke);
+            assertEq(tail[length - 1], array[array.length - 1]);
+        }
+    }
 }


### PR DESCRIPTION
Adversarial mutation testing pass on `src/lib/LibStackPointer.sol`, batch `s2`.

Baseline: 262 passed, 0 failed. Negative control (reordering the two provably
independent `mload`s in `unsafePeek2`) correctly **survived**, confirming the
harness can report a survivor.

## Behaviour -> mutation -> outcome

| Behaviour | Mutation | Outcome |
|---|---|---|
| P09 `unsafeList` length-prefix word offset | `add(0x20, mul(length, 0x20))` -> `add(0x00, ...)` | killed by `testUnsafeList` |
| P10 `unsafeList` per-item word size | `mul(length, 0x20)` -> `mul(length, 0x40)` | killed by `testUnsafeList` |
| P11 head read ordered before the length write | swapped `head := mload(tail)` and `mstore(tail, length)` | killed by `testUnsafeList` |
| P12 stored length value | `mstore(tail, length)` -> `mstore(tail, add(length, 1))` | killed by `testUnsafeList` |
| **Aliasing / in-place construction** | keep the in-place length write, but return a `tail` copied into freshly allocated memory | **SURVIVED -> new test** |

## The gap

`unsafeList` is documented to return the values "without allocating new memory",
with a returned array that is "ONLY valid for as long as the stack DOES NOT move
back into its memory" — i.e. `tail` must *alias* the source stack memory.

`testUnsafeList` only compared `tail`'s **contents** against a pre-copied
expectation and asserted that the length word landed in the source array. An
implementation that wrote the length in place but then copied the elements out
to a fresh allocation satisfied every existing assertion, so the aliasing
guarantee itself was unpinned.

## Killing test

`testUnsafeListAliasesSourceWithoutAllocating` pins three exact properties:

- the free memory pointer is byte-for-byte unchanged across the call (no allocation);
- `tail.startPointer() == pointer - 0x20 * (length + 1)` exactly;
- writing through `tail[0]` is observable as `array[array.length - length]`.

Verified both directions: passes on clean `main`, fails under the copying mutation.

Suite: 263 passed, 0 failed.
