### PR TITLE
test(stack-s5): mutation-validated coverage

### DIFF
--- a/test/src/lib/LibStackSentinel.t.sol
+++ b/test/src/lib/LibStackSentinel.t.sol
@@ -113,8 +113,14 @@ contract LibStackSentinelTest is Test {
         vm.assume((stack.length - (sentinelIndex + 1)) % 2 == 0);
         stack[sentinelIndex] = Sentinel.unwrap(sentinel);
 
+        // The tuples array MUST be allocated exactly at the free memory
+        // pointer, i.e. with no gap between the prior allocation and the
+        // length slot of the tuples array.
+        Pointer expectedTuplesPointer = LibPointer.allocatedMemoryPointer();
+
         (Pointer sentinelPointer, Pointer tuplesPointer) =
             stack.dataPointer().consumeSentinelTuples(stack.endPointer(), sentinel, 2);
+        assertEq(Pointer.unwrap(tuplesPointer), Pointer.unwrap(expectedTuplesPointer));
         uint256[2][] memory tuples;
         assembly ("memory-safe") {
             tuples := tuplesPointer
@@ -150,8 +156,14 @@ contract LibStackSentinelTest is Test {
         vm.assume((stack.length - (sentinelIndex + 1)) % 3 == 0);
         stack[sentinelIndex] = Sentinel.unwrap(sentinel);
 
+        // The tuples array MUST be allocated exactly at the free memory
+        // pointer, i.e. with no gap between the prior allocation and the
+        // length slot of the tuples array.
+        Pointer expectedTuplesPointer = LibPointer.allocatedMemoryPointer();
+
         (Pointer sentinelPointer, Pointer tuplesPointer) =
             stack.dataPointer().consumeSentinelTuples(stack.endPointer(), sentinel, 3);
+        assertEq(Pointer.unwrap(tuplesPointer), Pointer.unwrap(expectedTuplesPointer));
         uint256[3][] memory tuples;
         assembly ("memory-safe") {
             tuples := tuplesPointer
@@ -275,6 +287,10 @@ contract LibStackSentinelTest is Test {
             lower.consumeSentinelTuples(lower.unsafeAddWord(), sentinel, 2);
         assertEq(Pointer.unwrap(sentinelPointer), Pointer.unwrap(lower));
         assertEq(tuplesPointer.unsafeReadWord(), 0);
+        // A zero length tuples array is still allocated exactly at the free
+        // memory pointer, and consumes exactly one word for its length.
+        assertEq(Pointer.unwrap(tuplesPointer), Pointer.unwrap(lower));
+        assertEq(Pointer.unwrap(LibPointer.allocatedMemoryPointer()), Pointer.unwrap(tuplesPointer.unsafeAddWord()));
     }
 
     function testConsumeSentinelTuplesGas0() external pure {


### PR DESCRIPTION
Adversarial mutation testing pass on `src/lib/LibStackSentinel.sol`, batch `s5`.

Baseline: 262 passed, 0 failed. Negative control (yul local rename `tuplesCursor` -> `tCur`) correctly SURVIVED, so the harness can report survivors.

## Ledger

| Behaviour | Mutation | Outcome | Killed by |
|---|---|---|---|
| S09 `InvalidStackBounds` boundary at `upper == lower` | `upper < lower` -> `upper <= lower` | killed | `testConsumeSentinelTuplesEmptyError`, `testConsumeSentinelTuplesMissingSentinel` |
| S10 `InvalidStackBounds` operand order | `revert InvalidStackBounds(lower, upper)` -> `(upper, lower)` | killed | `testConsumeSentinelTuplesInitialStateUnderflowError` |
| S11 tuples array allocated at `mload(0x40)` | `tuplesPointer := sub(mload(0x40), 0x20)` | killed | `testConsumeSentinelTuplesMultiSize` |
| S11 (opposite direction) | `tuplesPointer := add(mload(0x40), 0x20)` | **survived -> filled** | `testConsumeSentinelTuples`, `testConsumeSentinelTuples3`, `testConsumeSentinelTuplesEmpty` (strengthened here) |
| S12 `tuplesCursor` initial offset `0x20` past the length slot | `add(tuplesPointer, 0x20)` -> `0x40` | killed | `testConsumeSentinelTuples`, `...3`, `...Empty`, `...Multiple`, `...MultiSize` |
| S13 build loop starts one word above the sentinel | `add(sentinelPointer, 0x20)` -> `0x40` | killed | `testConsumeSentinelTuples`, `...3`, `...Multiple`, `...MultiSize` |
| S14 build loop bound `lt(cursor, upper)` exclusivity | `lt(cursor, upper)` -> `iszero(gt(cursor, upper))` | killed | `testConsumeSentinelTuples`, `...3`, `...Empty`, `...Multiple`, `...MultiSize` |
| S15 build loop cursor step of `size` | `cursor := add(cursor, size)` -> `add(cursor, 0x20)` | killed | `testConsumeSentinelTuples`, `...3`, `...Multiple`, `...MultiSize` |
| S16 build loop `tuplesCursor` step of `0x20` | `add(tuplesCursor, 0x20)` -> `0x40` | killed | `testConsumeSentinelTuples`, `...3`, `...Multiple`, `...MultiSize` |

## The gap this PR fills

The existing tests pinned only the END of the tuples allocation:

```solidity
assertEq(
    Pointer.unwrap(tuplesPointer.unsafeAddWords(tuples.length + 1)),
    Pointer.unwrap(LibPointer.allocatedMemoryPointer())
);
```

That relation holds under any leading gap, because the assembly writes `mstore(0x40, tuplesCursor)` from wherever `tuplesPointer` happened to start. Allocating the array one word above the free memory pointer therefore left a leaked, uninitialised word and no test noticed.

Since `consumeSentinelTuples` declares `assembly ("memory-safe")`, allocating exactly at `mload(0x40)` is a requirement rather than an incidental detail, so the behaviour is pinned rather than reported as a bug.

The existing tests are strengthened in place (not duplicated), capturing the free memory pointer before the call and asserting `tuplesPointer` equals it. Verified in both directions: passes clean, fails under the mutation.

Suite green at 262 passed, 0 failed.
