### PR TITLE
Record the adversarial mutation scan of v0.1.3

### DIFF
--- a/audit/mutation-test-scans.json
+++ b/audit/mutation-test-scans.json
@@ -1,0 +1,19 @@
+[
+  {
+    "timestamp": "2026-07-20T15:41:05Z",
+    "commit": "b3bd859",
+    "publishedTag": "v0.1.3",
+    "commitsAheadOfTag": 10,
+    "scope": "whole repo",
+    "tool": "adversarial-mutation-test",
+    "skillVersion": "0.27.0",
+    "summary": {
+      "baseline": 262,
+      "behaviours": 205,
+      "candidates": 27,
+      "confirmed": 3,
+      "filed": ["#50", "#54", "#55"],
+      "coveragePrs": ["#47", "#48", "#49", "#51", "#52", "#53"]
+    }
+  }
+]


### PR DESCRIPTION
Adds `audit/mutation-test-scans.json` — the committed record an org-wide health check reads to tell a recently-scanned repo from a stale one, and to know **which release** was audited.

| | |
|---|---|
| scanned commit | `b3bd859` |
| published tag at that commit | `v0.1.3` (10 commits behind HEAD) |
| scope | whole repo |
| baseline | 262 passing, verified by every worker before probing |
| behaviours probed | 205 |
| issues filed | #50, #54, #55 |
| coverage PRs | #47, #48, #49, #51, #52, #53 |

Recording the tag as well as the commit matters here: the scan ran 10 commits **past** `v0.1.3`, so this is not a clean statement that the release was audited — a health check that only stored a date would imply more than the run actually establishes.

No source or test changes; this is the audit artefact only.