### PR TITLE
Read the extend length before overwriting base's length word

### DIFF
--- a/src/lib/LibBytes32Array.sol
+++ b/src/lib/LibBytes32Array.sol
@@ -345,11 +345,17 @@ library LibBytes32Array {
                     baseAfter := extendInline(newBase, extend)
                 }
                 case 1 {
-                    let totalLength := add(baseLength, mload(extend))
+                    // Read the extend length ONCE, before base's length word is
+                    // overwritten. When extend aliases base they are the same
+                    // word, so re-reading it after the write yields the already
+                    // combined length and the copy runs past the free memory
+                    // pointer.
+                    let extendLength := mload(extend)
+                    let totalLength := add(baseLength, extendLength)
                     let outputEnd := add(base, add(0x20, mul(totalLength, 0x20)))
                     mstore(base, totalLength)
                     mstore(0x40, outputEnd)
-                    mcopy(baseEnd, add(extend, 0x20), mul(mload(extend), 0x20))
+                    mcopy(baseEnd, add(extend, 0x20), mul(extendLength, 0x20))
 
                     baseAfter := base
                 }

--- a/src/lib/LibUint256Array.sol
+++ b/src/lib/LibUint256Array.sol
@@ -345,11 +345,17 @@ library LibUint256Array {
                     baseAfter := extendInline(newBase, extend)
                 }
                 case 1 {
-                    let totalLength := add(baseLength, mload(extend))
+                    // Read the extend length ONCE, before base's length word is
+                    // overwritten. When extend aliases base they are the same
+                    // word, so re-reading it after the write yields the already
+                    // combined length and the copy runs past the free memory
+                    // pointer.
+                    let extendLength := mload(extend)
+                    let totalLength := add(baseLength, extendLength)
                     let outputEnd := add(base, add(0x20, mul(totalLength, 0x20)))
                     mstore(base, totalLength)
                     mstore(0x40, outputEnd)
-                    mcopy(baseEnd, add(extend, 0x20), mul(mload(extend), 0x20))
+                    mcopy(baseEnd, add(extend, 0x20), mul(extendLength, 0x20))
 
                     baseAfter := base
                 }

--- a/test/src/lib/LibArray.selfExtend.t.sol
+++ b/test/src/lib/LibArray.selfExtend.t.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {LibUint256Array} from "src/lib/LibUint256Array.sol";
+import {LibBytes32Array} from "src/lib/LibBytes32Array.sol";
+
+/// Extending an array by itself. The inline path reads the extend length for
+/// the copy size, and when extend aliases base that read has to happen before
+/// base's length word is rewritten.
+contract LibArraySelfExtendTest is Test {
+    using LibUint256Array for uint256[];
+    using LibBytes32Array for bytes32[];
+
+    /// The assembly is annotated ("memory-safe"), which promises the compiler
+    /// nothing is written at or above the free memory pointer the block leaves.
+    /// Canaries planted above it must survive.
+    function testSelfExtendUint256WritesNothingAboveFreeMemoryPointer() external pure {
+        uint256[] memory a = new uint256[](3);
+        a[0] = 0x11;
+        a[1] = 0x22;
+        a[2] = 0x33;
+
+        uint256 fmpBefore;
+        assembly ("memory-safe") {
+            fmpBefore := mload(0x40)
+        }
+        assembly ("memory-safe") {
+            mstore(add(fmpBefore, 0x60), 0xdead0001)
+            mstore(add(fmpBefore, 0xa0), 0xdead0002)
+        }
+
+        a.unsafeExtend(a);
+
+        uint256 canary1;
+        uint256 canary2;
+        assembly ("memory-safe") {
+            canary1 := mload(add(fmpBefore, 0x60))
+            canary2 := mload(add(fmpBefore, 0xa0))
+        }
+        assertEq(canary1, 0xdead0001, "wrote at or above the free memory pointer");
+        assertEq(canary2, 0xdead0002, "wrote at or above the free memory pointer");
+    }
+
+    /// Self-extension copies the original elements once, so the result is the
+    /// array doubled rather than a longer run of whatever the copy overran.
+    function testSelfExtendUint256DoublesTheContents() external pure {
+        uint256[] memory a = new uint256[](3);
+        a[0] = 0x11;
+        a[1] = 0x22;
+        a[2] = 0x33;
+
+        uint256[] memory extended = a.unsafeExtend(a);
+
+        assertEq(extended.length, 6);
+        assertEq(extended[0], 0x11);
+        assertEq(extended[1], 0x22);
+        assertEq(extended[2], 0x33);
+        assertEq(extended[3], 0x11);
+        assertEq(extended[4], 0x22);
+        assertEq(extended[5], 0x33);
+    }
+
+    function testSelfExtendBytes32WritesNothingAboveFreeMemoryPointer() external pure {
+        bytes32[] memory a = new bytes32[](3);
+        a[0] = bytes32(uint256(0x11));
+        a[1] = bytes32(uint256(0x22));
+        a[2] = bytes32(uint256(0x33));
+
+        uint256 fmpBefore;
+        assembly ("memory-safe") {
+            fmpBefore := mload(0x40)
+        }
+        assembly ("memory-safe") {
+            mstore(add(fmpBefore, 0x60), 0xdead0001)
+        }
+
+        a.unsafeExtend(a);
+
+        uint256 canary1;
+        assembly ("memory-safe") {
+            canary1 := mload(add(fmpBefore, 0x60))
+        }
+        assertEq(canary1, 0xdead0001, "wrote at or above the free memory pointer");
+    }
+
+    function testSelfExtendBytes32DoublesTheContents() external pure {
+        bytes32[] memory a = new bytes32[](2);
+        a[0] = bytes32(uint256(0xAA));
+        a[1] = bytes32(uint256(0xBB));
+
+        bytes32[] memory extended = a.unsafeExtend(a);
+
+        assertEq(extended.length, 4);
+        assertEq(extended[0], bytes32(uint256(0xAA)));
+        assertEq(extended[1], bytes32(uint256(0xBB)));
+        assertEq(extended[2], bytes32(uint256(0xAA)));
+        assertEq(extended[3], bytes32(uint256(0xBB)));
+    }
+}

--- a/test/src/lib/LibArray.selfExtend.t.sol
+++ b/test/src/lib/LibArray.selfExtend.t.sol
@@ -26,7 +26,11 @@ contract LibArraySelfExtendTest is Test {
         assembly ("memory-safe") {
             fmpBefore := mload(0x40)
         }
-        assembly ("memory-safe") {
+        // Deliberately NOT ("memory-safe"): this writes above the free memory
+        // pointer on purpose. Claiming memory-safe here would let the optimizer
+        // assume the region is untouched and fold the read below into a
+        // constant, so the test could pass even after a regression.
+        assembly {
             mstore(add(fmpBefore, 0x60), 0xdead0001)
             mstore(add(fmpBefore, 0xa0), 0xdead0002)
         }
@@ -35,7 +39,7 @@ contract LibArraySelfExtendTest is Test {
 
         uint256 canary1;
         uint256 canary2;
-        assembly ("memory-safe") {
+        assembly {
             canary1 := mload(add(fmpBefore, 0x60))
             canary2 := mload(add(fmpBefore, 0xa0))
         }
@@ -72,14 +76,15 @@ contract LibArraySelfExtendTest is Test {
         assembly ("memory-safe") {
             fmpBefore := mload(0x40)
         }
-        assembly ("memory-safe") {
+        // Deliberately NOT ("memory-safe") — see above.
+        assembly {
             mstore(add(fmpBefore, 0x60), 0xdead0001)
         }
 
         a.unsafeExtend(a);
 
         uint256 canary1;
-        assembly ("memory-safe") {
+        assembly {
             canary1 := mload(add(fmpBefore, 0x60))
         }
         assertEq(canary1, 0xdead0001, "wrote at or above the free memory pointer");


### PR DESCRIPTION
Closes #50

The inline path re-read `mload(extend)` for the mcopy size **after** writing base's combined length. When `extend` aliases `base` those are the same word, so the size came back already doubled and the copy ran past the free memory pointer the block had just set.

```diff
 case 1 {
-    let totalLength := add(baseLength, mload(extend))
+    let extendLength := mload(extend)
+    let totalLength := add(baseLength, extendLength)
     let outputEnd := add(base, add(0x20, mul(totalLength, 0x20)))
     mstore(base, totalLength)
     mstore(0x40, outputEnd)
-    mcopy(baseEnd, add(extend, 0x20), mul(mload(extend), 0x20))
+    mcopy(baseEnd, add(extend, 0x20), mul(extendLength, 0x20))
```

Applied to **both** `LibUint256Array` and `LibBytes32Array`, which carried the identical pattern.

## Why it matters

`("memory-safe")` is a contract with the **compiler**, not the caller — Solidity relies on it for stack-to-memory and via-IR spilling, and no `unsafe*` naming or NatSpec caveat can waive it. For a three-element array the copy overran by `0x60` bytes.

## Evidence

| test | on base | with fix |
|---|---|---|
| `testSelfExtendUint256WritesNothingAboveFreeMemoryPointer` | **FAIL** `0 != 3735879681` | PASS |
| `testSelfExtendBytes32WritesNothingAboveFreeMemoryPointer` | **FAIL** `0 != 3735879681` | PASS |
| `testSelfExtendUint256DoublesTheContents` | PASS | PASS |
| `testSelfExtendBytes32DoublesTheContents` | PASS | PASS |

Verified by stashing only the `src/` change and re-running. The two canary tests are the discriminating ones — they plant words above the free memory pointer and read them back clobbered on the old code. The two contents tests **pass on base as well**: the overrun writes beyond the array but only the first six words are ever read, so contents alone cannot detect this. They are regression guards, not evidence.

Whole suite: **266 passing** (262 baseline + 4).

## What this does NOT fix

The NatSpec still says, unconditionally:

> It is safe to use the extend array after calling this function as it is never mutated, it is only copied from.

With `base == extend` the length word **is** mutated, because they are the same word — that is inherent to self-aliasing and no reordering fixes it. Resolving it means either scoping the sentence (*"provided extend does not alias base"*) or rejecting aliasing outright. That is a design decision and I have deliberately left it to you rather than pick one; it is split out as #61 (scope the NatSpec to a non-aliasing precondition, or reject aliasing outright), so this PR legitimately closes #50.

## Note on audit drift

`rain.solmem` is Protofire-audited at `228b35c6` and currently reads `stale` at +8/−0 code LOC over 45 commits, with 23 repos inheriting it. This adds ~4 more lines of audited-source drift. Worth weighing against leaving a memory-safety defect in place, but it is a real cost and the sibling doc-only PRs for #54 and #55 were deliberately kept code-free for that reason.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed self-extending dynamic arrays that could write beyond the allocated memory boundary.
  * Ensured arrays correctly duplicate their contents and update their length when extended in place.

* **Tests**
  * Added coverage for self-extension of `uint256[]` and `bytes32[]` arrays.
  * Added safeguards verifying memory outside the allocated region remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
