### PR TITLE
Say that toIndexSigned needs relative, not absolute, alignment

### DIFF
--- a/src/lib/LibStackPointer.sol
+++ b/src/lib/LibStackPointer.sol
@@ -142,8 +142,12 @@ library LibStackPointer {
 
     /// Convert two stack pointer values to a single stack index. A stack index
     /// is the distance in 32 byte increments between two stack pointers. The
-    /// calculations require the two stack pointers are aligned. If the pointers
-    /// are not aligned, the function will revert.
+    /// calculations require the two stack pointers to be aligned WITH EACH
+    /// OTHER to 32 bytes, i.e. that the distance between them is a whole number
+    /// of words. Neither pointer need be 32 byte aligned in absolute terms: a
+    /// shared sub-word offset cancels out of the distance and is discarded by
+    /// the truncating division. If the distance is not word aligned the
+    /// function will revert with `UnalignedStackPointer`.
     ///
     /// @param lower The lower of the two values.
     /// @param upper The higher of the two values.

--- a/src/lib/LibStackPointer.sol
+++ b/src/lib/LibStackPointer.sol
@@ -149,8 +149,9 @@ library LibStackPointer {
     /// the truncating division. If the distance is not word aligned the
     /// function will revert with `UnalignedStackPointer`.
     ///
-    /// @param lower The lower of the two values.
-    /// @param upper The higher of the two values.
+    /// @param lower The pointer the index is measured from.
+    /// @param upper The pointer the index is measured to. MAY be below `lower`,
+    /// in which case the index is negative.
     /// @return The stack index as 32 byte words distance between the top and
     /// bottom. Negative if `lower` is above `upper`.
     function toIndexSigned(Pointer lower, Pointer upper) internal pure returns (int256) {

--- a/test/src/lib/LibStackPointer.toIndexSigned.t.sol
+++ b/test/src/lib/LibStackPointer.toIndexSigned.t.sol
@@ -67,6 +67,40 @@ contract LibStackPointerToIndexSignedTest is Test {
         assertEq(LibStackPointer.toIndexSigned(Pointer.wrap(0x100), Pointer.wrap(0x80)), -4);
     }
 
+    /// Alignment is relative, not absolute. Neither pointer is 32 byte aligned
+    /// in absolute terms, but the distance between them is a whole number of
+    /// words, so the index resolves rather than reverting.
+    function testToIndexSignedRelativeAlignmentOnly() public pure {
+        assertEq(LibStackPointer.toIndexSigned(Pointer.wrap(0x10), Pointer.wrap(0x30)), 1);
+        assertEq(LibStackPointer.toIndexSigned(Pointer.wrap(0x30), Pointer.wrap(0x10)), -1);
+        assertEq(LibStackPointer.toIndexSigned(Pointer.wrap(0x1f), Pointer.wrap(0x9f)), 4);
+        assertEq(LibStackPointer.toIndexSigned(Pointer.wrap(0x9f), Pointer.wrap(0x1f)), -4);
+    }
+
+    /// A sub-word offset shared by both pointers cancels out of the distance and
+    /// is discarded by the truncating division, so the index is the same as it
+    /// would be for the aligned pair.
+    function testToIndexSignedSharedResidueCancels(uint256 base, uint8 residue, int16 words) public pure {
+        residue = uint8(bound(residue, 0, 0x1f));
+        // Keep the base well away from both ends of the range so that shifting
+        // by `words` can neither underflow nor overflow.
+        base = bound(base, 1 << 40, 1 << 200);
+        base -= base % 0x20;
+
+        uint256 lower = base + residue;
+        //forge-lint: disable-next-line(unsafe-typecast)
+        uint256 upper = uint256(int256(lower) + int256(words) * 0x20);
+
+        assertEq(LibStackPointer.toIndexSigned(Pointer.wrap(lower), Pointer.wrap(upper)), int256(words));
+    }
+
+    /// Residues that do not match leave a distance that is not a whole number of
+    /// words, which reverts even though `lower` is absolutely aligned.
+    function testToIndexSignedMismatchedResiduesRevert() public {
+        vm.expectRevert(abi.encodeWithSelector(UnalignedStackPointer.selector, Pointer.wrap(0x20), Pointer.wrap(0x38)));
+        this.toIndexSignedExternal(Pointer.wrap(0x20), Pointer.wrap(0x38));
+    }
+
     /// Test that unaligned pointers throw.
     function testUnsafeToIndexUnalignedLower(Pointer lower, Pointer upper) public {
         uint256 difference = Pointer.unwrap(upper) >= Pointer.unwrap(lower)


### PR DESCRIPTION
Closes #55

**Documentation only — no code change, so no added audited-source drift.**

The NatSpec read as a requirement on each pointer:

> The calculations require the two stack pointers are aligned. If the pointers are not aligned, the function will revert.

while `UnalignedStackPointer` already documented the real rule — *"unaligned **with each other** (32 bytes)"* — and the guard checks `distance % 0x20`. Two docs in one repo, disagreeing.

## The code is correct; do not "fix" it

Worth being explicit, because the tempting change is the wrong one. The relative check is **sufficient**:

```solidity
int256(Pointer.unwrap(upper) / 0x20) - int256(Pointer.unwrap(lower) / 0x20)
```

For a shared residue `r < 0x20` the truncating division discards `r` on both sides, yielding the exact word distance. Verified against unmutated source:

```
Pointer.wrap(0x10).toIndexSigned(Pointer.wrap(0x30))  ==  1    // neither aligned
Pointer.wrap(0x1f).toIndexSigned(Pointer.wrap(0x9f))  ==  4    // neither aligned
Pointer.wrap(0x9f).toIndexSigned(Pointer.wrap(0x1f))  == -4
Pointer.wrap(0x10).toIndexSigned(Pointer.wrap(0x38))  -> reverts (residues differ)
```

Tightening the guard to demand absolute alignment would **reject inputs the arithmetic handles correctly**. So this PR changes the description to match the implementation and the error declaration, and leaves the logic alone.

Found independently by two adversarial-mutation-test workers in separate runs, which is why it is filed despite being cosmetic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that stack pointers must be aligned with each other on 32-byte (word) boundaries, and explained how sub-word offsets are handled.
  * Updated the `toIndexSigned` documentation to note that non–word-aligned distances revert with `UnalignedStackPointer`.
  * Relaxed parameter description to allow `upper` to be lower than `lower` (yielding a negative index).

* **Tests**
  * Added coverage for relative alignment validity, residue cancellation behavior, and mismatched residue reverts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->