### PR TITLE
Warn that unsafeCopyWordsTo can silently overflow

### DIFF
--- a/src/lib/LibMemCpy.sol
+++ b/src/lib/LibMemCpy.sol
@@ -29,6 +29,14 @@ library LibMemCpy {
     /// already written to memory at `[target:target+(length * 32 bytes)]`
     /// will be overwritten.
     /// There is no return value as memory is modified directly.
+    ///
+    /// This is UNSAFE because the byte count `length * 32` is computed in
+    /// unchecked assembly and can silently overflow. A `length` at or above
+    /// `2**251` wraps, so the copy silently moves a small number of bytes and
+    /// RETURNS SUCCESSFULLY rather than running out of gas: `2**251` copies
+    /// nothing at all, and `2**251 + 1` copies exactly one word. The caller
+    /// MUST ensure `length` is a real word count.
+    ///
     /// @param source The starting position in memory that data will be copied
     /// from.
     /// @param target The starting position in memory that data will be copied

--- a/src/lib/LibMemCpy.sol
+++ b/src/lib/LibMemCpy.sol
@@ -31,11 +31,21 @@ library LibMemCpy {
     /// There is no return value as memory is modified directly.
     ///
     /// This is UNSAFE because the byte count `length * 32` is computed in
-    /// unchecked assembly and can silently overflow. A `length` at or above
-    /// `2**251` wraps, so the copy silently moves a small number of bytes and
-    /// RETURNS SUCCESSFULLY rather than running out of gas: `2**251` copies
-    /// nothing at all, and `2**251 + 1` copies exactly one word. The caller
-    /// MUST ensure `length` is a real word count.
+    /// unchecked assembly and can silently overflow. The number of bytes
+    /// actually copied is `(length mod 2**251) * 32`, so the wrap is PERIODIC:
+    /// it recurs at every multiple of `2**251` rather than being a tail above a
+    /// single threshold. What makes a `length` dangerous is a small RESIDUE, not
+    /// a large magnitude; most values at or above `2**251` still exhaust gas.
+    ///
+    /// The hazard is an unbounded silent OVER-COPY. When the residue is
+    /// affordable but larger than the caller's allocation, the copy writes far
+    /// past the end of that allocation, corrupts whatever follows, and RETURNS
+    /// SUCCESSFULLY. `2**251 + 1000` writes 32,000 bytes over a 64 byte
+    /// allocation; `2**251 + 32768` copies a whole mebibyte for roughly 2.3
+    /// million gas. Small residues instead UNDER-copy, silently and benignly:
+    /// `2**251` copies nothing at all and `2**251 + 1` copies exactly one word.
+    ///
+    /// The caller MUST ensure `length` is a real word count.
     ///
     /// @param source The starting position in memory that data will be copied
     /// from.

--- a/test/src/lib/LibMemCpy.Words.t.sol
+++ b/test/src/lib/LibMemCpy.Words.t.sol
@@ -12,6 +12,14 @@ contract LibMemCpyWordsTest is Test {
     using LibPointer for Pointer;
     using LibUint256Array for uint256[];
 
+    /// Distinctive value written outside an allocation so that an over-copy is
+    /// observable. MUST NOT be zero, as unwritten memory reads as zero.
+    uint256 constant CANARY = 0xDEADBEEF;
+
+    /// The word count at which `mul(length, 0x20)` wraps a whole multiple of
+    /// `2**256`, i.e. `2**256 / 32`.
+    uint256 constant OVERFLOW_PERIOD = 1 << 251;
+
     function testCopyFuzz(uint256[] memory source, uint256 suffix) public pure {
         uint256[] memory target = new uint256[](source.length);
         uint256 end;
@@ -120,6 +128,83 @@ contract LibMemCpyWordsTest is Test {
         assertEq(buffer[3], 6);
         assertEq(buffer[4], 5);
         assertEq(buffer[5], 6);
+    }
+
+    /// The byte count is `mul(length, 0x20)` in unchecked assembly, so it is
+    /// `(length mod 2**251) * 32`. At exactly `2**251` the residue is zero, so
+    /// the copy moves NOTHING and returns successfully instead of exhausting
+    /// gas on a `2**256` byte copy.
+    function testCopyWordsOverflowPeriodCopiesNothing() public pure {
+        uint256[] memory source = new uint256[](2);
+        source[0] = 7;
+        source[1] = 8;
+
+        uint256[] memory target = new uint256[](2);
+        target[0] = 111;
+        target[1] = 222;
+
+        LibMemCpy.unsafeCopyWordsTo(source.dataPointer(), target.dataPointer(), OVERFLOW_PERIOD);
+
+        assertEq(target[0], 111);
+        assertEq(target[1], 222);
+    }
+
+    /// One word above the period the residue is one, so a `length` far larger
+    /// than all of memory copies exactly one word.
+    function testCopyWordsOverflowResidueOneCopiesOneWord() public pure {
+        uint256[] memory source = new uint256[](2);
+        source[0] = 7;
+        source[1] = 8;
+
+        uint256[] memory target = new uint256[](2);
+        target[0] = 111;
+        target[1] = 222;
+
+        LibMemCpy.unsafeCopyWordsTo(source.dataPointer(), target.dataPointer(), OVERFLOW_PERIOD + 1);
+
+        assertEq(target[0], 7);
+        assertEq(target[1], 222);
+    }
+
+    /// The hazardous direction: a residue small enough to be affordable but
+    /// larger than the target allocation copies a large number of bytes past the
+    /// end of that allocation and RETURNS SUCCESSFULLY. `2**251 + 1000` writes
+    /// 32,000 bytes over a 64 byte target. Canaries pin where it stops: the last
+    /// word inside the wrapped range is destroyed, the word after it is not.
+    function testCopyWordsOverflowOverCopiesPastAllocation() public pure {
+        uint256[] memory source = new uint256[](2);
+        source[0] = 7;
+        source[1] = 8;
+
+        uint256[] memory target = new uint256[](2);
+        target[0] = 111;
+        target[1] = 222;
+
+        uint256 copiedBytes = 1000 * 0x20;
+        uint256 targetData = Pointer.unwrap(target.dataPointer());
+        uint256 inside = targetData + copiedBytes - 0x20;
+        uint256 outside = targetData + copiedBytes;
+        assembly ("memory-safe") {
+            mstore(inside, CANARY)
+            mstore(outside, CANARY)
+            // Keep solidity's allocator clear of the canaries so that only the
+            // copy under test can touch them.
+            mstore(0x40, add(outside, 0x20))
+        }
+
+        LibMemCpy.unsafeCopyWordsTo(source.dataPointer(), target.dataPointer(), OVERFLOW_PERIOD + 1000);
+
+        uint256 insideAfter;
+        uint256 outsideAfter;
+        assembly ("memory-safe") {
+            insideAfter := mload(inside)
+            outsideAfter := mload(outside)
+        }
+
+        // Silent corruption: 31,936 bytes beyond the 64 byte allocation were
+        // overwritten and the call still returned.
+        assertTrue(insideAfter != CANARY, "over-copy must reach the last word of the wrapped length");
+        assertEq(outsideAfter, CANARY, "over-copy must stop at exactly (length mod 2**251) * 32 bytes");
     }
 
     // Uses somewhat circular logic to test that existing data in target cannot


### PR DESCRIPTION
Partially addresses #54 — **NatSpec and tests only, no `src/` logic change**, so no added audited-source drift.

`unsafeCopyWordsTo` was the single place in `LibPointer`/`LibMemCpy` where a silent overflow existed **and was undocumented**. Its siblings — `unsafeAddBytes`, `unsafeAddWord`, `unsafeAddWords`, `unsafeSubWord`, `unsafeSubWords` — all carry *"This is UNSAFE because it can silently overflow"*. This one instead stated flatly that it *"Copies `length` `uint256` values"*.

Verified against unmutated `b3bd859`:

| `length` | bytes copied | outcome |
|---|---|---|
| `2**251` | **0** | returns successfully, nothing copied |
| `2**251 + 1` | **32** | returns successfully, exactly one word copied |

That is quieter than the failure the library describes elsewhere for a violated precondition (*"will underflow (and exhaust gas attempting to read)"*), so the warning now says so explicitly.

## Deliberately not doing the rest

#54 covers **three** sites — this one plus `LibStackSentinel.consumeSentinelTuples` and `LibStackPointer.unsafeList`. I have only documented this one, and I have not added any bounds guard anywhere. Reasons:

1. **Guard vs document is your call, not mine.** Adding `if (n > type(uint256).max / 0x20) revert` to `unsafe*` functions costs gas on hot paths whose entire premise is that they do not check. The library's established convention is clearly *document, don't guard* — five siblings prove it. I have followed that convention rather than overriding it, but a guard is defensible too and I am not the one to decide.
2. **This site is the one where the convention was simply not applied.** Fixing that is unambiguous. The other two would need their existing "fails loudly on gas" wording rewritten, which is a larger doc change worth doing together with whatever you decide on (1).

So #54 stays open. If you want guards, say so and I will do all three properly; if you want the remaining two documented the same way, that is a small follow-up.

Zero code change means this does not move `rain.solmem` further from its Protofire anchor (`228b35c6`), which already reads `stale` at +8/−0 over 45 commits with 23 repos inheriting it.


Refs #54
