### PR TITLE
Document the audit/ directory and its filename anchor convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,25 @@ Tag `v<x.y.z>` on `main`. The
 `forge soldeer push rain-solmem~<x.y.z>` on every `v*` tag. The package name is
 derived from the repo name with `.` substituted for `-`.
 
+## Audit
+
+External audit reports live in `audit/protofire/`. The **filename encodes the
+audited git ref**, which is what lets tooling measure drift against the exact
+state that was reviewed rather than guessing from the file's commit date:
+
+```
+rain.solmem.228b35c6725877e7fbcd2432b4c692357f16f510.jan-2026.pdf
+            ^ the audited commit
+```
+
+Either a `v<x.y.z>` tag or a 7–40 character commit sha is recognised. A report
+named without one still counts as an audit, but its drift is dated from the
+commit that added the PDF, which is less precise.
+
+Because the anchor is a real ref, "has this been audited?" and "has the audited
+source changed since?" are separate questions with separate answers — a release
+tag alone does not tell you the second one.
+
 ## License
 
 DecentraLicense 1.0 (DCL-1.0) — full text in

--- a/README.md
+++ b/README.md
@@ -70,13 +70,58 @@ rain.solmem.228b35c6725877e7fbcd2432b4c692357f16f510.jan-2026.pdf
             ^ the audited commit
 ```
 
-Either a `v<x.y.z>` tag or a 7–40 character commit sha is recognised. A report
-named without one still counts as an audit, but its drift is dated from the
-commit that added the PDF, which is less precise.
+Two anchor forms are recognised, and a **tag wins** if a filename carries both:
+
+- A `[sol-]v<x.y.z>` tag. The `sol-` prefix is part of the tag rather than
+  decoration, and the result MUST be a tag that actually exists in this repo.
+  The newest tag here is `sol-v0.1.4`; there is no bare `v0.1.4`, so a filename
+  saying `v0.1.4` would resolve to nothing.
+- A 7–40 character hex commit sha, which MUST resolve to a real commit in this
+  repo. A hex-looking token that resolves to nothing is not an error — it
+  silently degrades to unanchored.
 
 Because the anchor is a real ref, "has this been audited?" and "has the audited
 source changed since?" are separate questions with separate answers — a release
 tag alone does not tell you the second one.
+
+### An unanchored report is dated by the wrong commit
+
+A report named without a resolvable anchor still counts as audited, but its
+drift is dated from **the most recent commit to touch the PDF**, not the commit
+that added it. Any later move, rename or re-commit silently resets that base to
+the day it happened.
+
+This repo is its own example. The PDF was moved into `audit/protofire/` on
+2026-07-15, while the commit it anchors, `228b35c6`, dates from 2025-12-06.
+Strip the anchor out of the filename and the audit reads as ~10 days old when
+the reviewed source is in fact 231 days stale.
+
+### The scope is exactly `audit/protofire/`
+
+A PDF anywhere else under `audit/` is **not counted as an external audit**. The
+scan deliberately walks `audit/protofire/` and only two levels deep, so a report
+left at `audit/report.pdf` is silently invisible rather than merely misfiled.
+
+### Also under `audit/`
+
+`audit/mutation-test-scans.json` is the adversarial-mutation-test scan record: a
+JSON array of run objects at the `audit/` root, one per run. It is read for the
+newest entry **by timestamp**, never by position, so entries may be appended out
+of order.
+
+`audit/` and `.audit/` are different directories, with different owners and
+different consumers. `.audit/` holds the audit skill's own run stamp
+(`.audit/runs.jsonl`), written by that skill; `audit/` holds artifacts committed
+deliberately. This repo has no `.audit/` yet, so the first audit-skill run
+creates one — do not file its output under `audit/`, or vice versa.
+
+### Nothing enforces any of this
+
+The convention is kept by discipline. No CI check in this repo validates
+filenames, the directory layout, or the presence of any of these files. Every
+violation degrades silently: an unresolvable anchor, a misplaced PDF and a
+malformed scan record all read downstream as "less audited" rather than failing
+a check.
 
 ## License
 


### PR DESCRIPTION
Documents `audit/protofire/` and the filename-anchor convention. The convention is load-bearing — the ref embedded in a report's filename is what lets drift be measured against the exact reviewed state, rather than inferred from the PDF's own commit date — but it was written down nowhere in the repo, so it was discoverable only by reading the tooling that consumes it.

README-only. No `src/`, no `test/`.

---

**Also a deliberate experiment.** PRs #57, #58 and #59 all sit at `CodeRabbit: FAILURE` with **zero** findings behind them (0 unresolved threads, rainix legal/static/test all green), and the cause is ambiguous. Across the open PRs on this repo the two candidate explanations are perfectly collinear:

| | opened | touches `src/` | CodeRabbit |
|---|---|---|---|
| #47 #48 #49 #51 #52 #53 #56 | 13:24–15:41 | no | SUCCESS |
| #57 #58 #59 | 18:47–18:49 | yes | FAILURE |

Every green PR is *both* non-`src` *and* earlier; every red one is *both* `src` *and* later. So "CodeRabbit gates `src/` changes here" and "something changed around 18:00 (quota, rate limit, app state)" fit the data equally well, and sibling repos rule out an org-wide `src` rule — `rain.math.float` #256/#253 and `raindex` #2796 all touch `src/` and pass.

This PR breaks the tie: **non-`src`, opened now.**

- if it goes **SUCCESS** → the trigger is `src/`-related and specific to this repo
- if it goes **FAILURE** → the trigger is time/quota and has nothing to do with what any of those PRs contain

Either way the content stands on its own, so nothing here is throwaway.