### PR TITLE
test: pin truncate's accept/reject boundary in both array libs

### DIFF
--- a/test/src/lib/LibBytes32Array.truncate.t.sol
+++ b/test/src/lib/LibBytes32Array.truncate.t.sol
@@ -41,6 +41,42 @@ contract LibBytes32ArrayTruncateTest is Test {
         this.truncateExternal(a, newLength);
     }
 
+    /// `array.length + 1` is the first REJECTED length, for every array length
+    /// including zero. `testTruncateError` fuzzes `newLength` over the whole
+    /// uint256 range under `newLength > a.length`, so it essentially never
+    /// lands on the bound itself; this pins it exactly.
+    function testTruncateOneTooLongReverts(bytes32[] memory a) public {
+        uint256 length = a.length;
+        vm.expectRevert(abi.encodeWithSelector(OutOfBoundsTruncate.selector, length, length + 1));
+        this.truncateExternal(a, length + 1);
+    }
+
+    /// The empty array cannot be truncated to one. The degenerate case of the
+    /// bound, where `array.length + 1` is also the smallest nonzero length.
+    function testTruncateEmptyToOneReverts() public {
+        vm.expectRevert(abi.encodeWithSelector(OutOfBoundsTruncate.selector, 0, 1));
+        this.truncateExternal(new bytes32[](0), 1);
+    }
+
+    /// `array.length` is the largest ACCEPTED length — the other side of the
+    /// bound — and truncating to it is a no-op that neither allocates nor
+    /// disturbs any item.
+    function testTruncateToOwnLengthAccepted(bytes32[] memory a) public pure {
+        uint256 length = a.length;
+        bytes32[] memory b = new bytes32[](length);
+        for (uint256 i = 0; i < length; i++) {
+            b[i] = a[i];
+        }
+
+        Pointer allocatedBefore = LibPointer.allocatedMemoryPointer();
+        LibBytes32Array.truncate(a, length);
+        Pointer allocatedAfter = LibPointer.allocatedMemoryPointer();
+        assertEq(Pointer.unwrap(allocatedBefore), Pointer.unwrap(allocatedAfter), "truncate allocated");
+
+        assertEq(a.length, length, "length");
+        assertEq(a, b);
+    }
+
     function testTruncateGas0() public pure {
         LibBytes32Array.truncate(
             LibBytes32Array.arrayFrom(bytes32(uint256(1)), bytes32(uint256(2)), bytes32(uint256(3))), 1

--- a/test/src/lib/LibUint256Array.truncate.t.sol
+++ b/test/src/lib/LibUint256Array.truncate.t.sol
@@ -33,6 +33,38 @@ contract LibUint256ArrayTruncateTest is Test {
         this.truncateExternal(a, newLength);
     }
 
+    /// `array.length + 1` is the first REJECTED length, for every array length
+    /// including zero. `testTruncateError` fuzzes `newLength` over the whole
+    /// uint256 range under `newLength > a.length`, so it essentially never
+    /// lands on the bound itself; this pins it exactly.
+    function testTruncateOneTooLongReverts(uint256[] memory a) public {
+        uint256 length = a.length;
+        vm.expectRevert(abi.encodeWithSelector(OutOfBoundsTruncate.selector, length, length + 1));
+        this.truncateExternal(a, length + 1);
+    }
+
+    /// The empty array cannot be truncated to one. The degenerate case of the
+    /// bound, where `array.length + 1` is also the smallest nonzero length.
+    function testTruncateEmptyToOneReverts() public {
+        vm.expectRevert(abi.encodeWithSelector(OutOfBoundsTruncate.selector, 0, 1));
+        this.truncateExternal(new uint256[](0), 1);
+    }
+
+    /// `array.length` is the largest ACCEPTED length — the other side of the
+    /// bound — and truncating to it is a no-op that retains every item.
+    function testTruncateToOwnLengthAccepted(uint256[] memory a) public pure {
+        uint256 length = a.length;
+        uint256[] memory b = new uint256[](length);
+        for (uint256 i = 0; i < length; i++) {
+            b[i] = a[i];
+        }
+
+        LibUint256Array.truncate(a, length);
+
+        assertEq(a.length, length, "length");
+        assertEq(a, b);
+    }
+
     function testTruncateGas0() public pure {
         LibUint256Array.truncate(LibUint256Array.arrayFrom(1, 2, 3), 1);
     }


### PR DESCRIPTION
Closes #74

`truncate`'s guard `if (newLength > array.length)` had its accept/reject boundary unpinned in both array libs. The existing tests split the domain either side of the bound without landing on it: `testTruncate` assumes `newLength <= a.length`, `testTruncateError` assumes `newLength > a.length` over a full-range fuzzed `uint256`.

This adds boundary tests in place to both existing per-type truncate suites (no new file — the repo already has `LibUint256Array.truncate.t.sol` / `LibBytes32Array.truncate.t.sol`), pinning **both** sides of the bound:

- `testTruncateOneTooLongReverts` — `array.length + 1` is the first rejected length, for every array length.
- `testTruncateEmptyToOneReverts` — the degenerate case, truncating the empty array to one.
- `testTruncateToOwnLengthAccepted` — `array.length` is the largest accepted length, and truncating to it retains every item (and, for bytes32, does not move the free memory pointer).

One refinement to the issue's premise, worth recording: the issue reports the loosened-bound mutant leaving the whole suite green. On this run it did **not** — `testTruncateError` also failed, because Foundry's fuzzer sometimes draws `a.length + 1`. That makes the existing catch *seed-dependent*, which is arguably worse than no catch (it fails intermittently rather than never). The tests added here kill both mutants deterministically on every run, since they compute the boundary length rather than fuzzing toward it.

## QA
- Discriminating tests: `testTruncateOneTooLongReverts`, `testTruncateEmptyToOneReverts`, `testTruncateToOwnLengthAccepted` (each in both `LibUint256Array.truncate.t.sol` and `LibBytes32Array.truncate.t.sol`) — this is a coverage-gap issue against already-correct code, so the discriminator is the mutant, not an unfixed base: each test passes on unmutated `main` (14/14 in the two suites, 298 tests repo-wide) and fails under the mutation it targets, verified by applying each mutant and re-running the full suite.
- Mutations applied: `src/lib/LibUint256Array.sol:288` and `src/lib/LibBytes32Array.sol:288` (a) `newLength > array.length` → `newLength > array.length + 1` → 6 failures, killed deterministically by `testTruncateOneTooLongReverts` + `testTruncateEmptyToOneReverts` in both libs (`testTruncateError` also failed, but only by fuzz luck); (b) `>` → `>=` → 4 failures, killed deterministically by `testTruncateToOwnLengthAccepted` in both libs (`testTruncate` also failed, again only when the fuzzer drew equality). Both mutants restored via VCS; tree verified clean before commit.
- Oracle: `error OutOfBoundsTruncate(uint256 arrayLength, uint256 truncatedLength)` in `src/error/ErrUint256Array.sol` and its NatSpec — "not possible to truncate something and increase its length as the memory region after the array MAY be allocated for something else already". The expected revert arguments and their order come from the declared parameter names and that documented intent, independently of what `truncate` passes at the call site.
- Category check: issue asks to pin the accept/reject boundary in both `LibUint256Array` and `LibBytes32Array`; covered both libs and both sides of the bound. Adversarial pass found no bug candidate — rejecting `length + 1` and accepting `length` both match the documented intent, so these tests pin correct behaviour rather than enshrining it.

Co-Authored-By: Claude <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for truncation boundary conditions across bytes32 and uint256 arrays.
  * Verified invalid truncation lengths revert with the expected bounds error.
  * Confirmed truncating an array to its existing length is a no-op that preserves contents and memory state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->