### PR TITLE
test(uint256): bring the uint256 suite to parity with the bytes32 one

### DIFF
--- a/test/src/lib/LibUint256Array.allocation.t.sol
+++ b/test/src/lib/LibUint256Array.allocation.t.sol
@@ -16,34 +16,24 @@ import {LibPointer} from "src/lib/LibPointer.sol";
 /// Every one of these tests must read the free memory pointer IMMEDIATELY after
 /// the call under test. Assertions allocate, so any assertion made first moves
 /// the free memory pointer and destroys the measurement.
+///
+/// The same applies to the poisoned words, only more strictly. Memory at or
+/// above the free memory pointer is temporary memory belonging to whichever
+/// assembly block is currently running, so the language preserves nothing there
+/// from one block to the next. The poison tests therefore keep the whole
+/// measurement inline in exactly two assembly blocks sat flush against the call
+/// under test: one writes the sentinels and snapshots the pointer, the call
+/// runs, the next snapshots the pointer again and copies the sentinels down
+/// into an array allocated before any of it. The only boundary the poison
+/// crosses is the call being measured, which is the measurement itself and so
+/// cannot be removed. Every other boundary can, and is: no helper call sits on
+/// that path, because the compiler would be entitled to reuse the region for it
+/// and be mistaken for the call under test writing past its allocation.
 contract LibUint256ArrayAllocationTest is Test {
     using LibUint256Array for uint256[];
 
     /// Number of words of free memory poisoned above the free memory pointer.
     uint256 internal constant POISON_WORDS = 8;
-
-    /// Poison `POISON_WORDS` words of FREE memory starting at the free memory
-    /// pointer with per-word recognisable sentinels. Returns the free memory
-    /// pointer as it stood before the call under test.
-    function _poisonFreeMemory() internal pure returns (uint256 fmpBefore) {
-        assembly ("memory-safe") {
-            fmpBefore := mload(0x40)
-            for { let i := 0 } lt(i, 8) { i := add(i, 1) } {
-                mstore(add(fmpBefore, mul(i, 0x20)), add(0xF00D0000, i))
-            }
-        }
-    }
-
-    /// Copy the poisoned region into `captured`, which the caller allocated
-    /// BEFORE poisoning so that it sits below the poisoned region and is itself
-    /// never disturbed. Copying must happen before any assertion runs.
-    function _capture(uint256[POISON_WORDS] memory captured, uint256 fmpBefore) internal pure {
-        assembly ("memory-safe") {
-            for { let i := 0 } lt(i, 8) { i := add(i, 1) } {
-                mstore(add(captured, mul(i, 0x20)), mload(add(fmpBefore, mul(i, 0x20))))
-            }
-        }
-    }
 
     /// Every poisoned word that lies at or above the FINAL free memory pointer
     /// is still free memory and must therefore be untouched.
@@ -124,13 +114,24 @@ contract LibUint256ArrayAllocationTest is Test {
         base[0] = 0x11;
         base[1] = 0x22;
 
-        uint256 fmpBefore = _poisonFreeMemory();
+        // Poison, then the call under test, then snapshot and capture. The two
+        // assembly blocks sit flush against the call so the only boundary the
+        // poison crosses is the call being measured.
+        uint256 fmpBefore;
+        assembly ("memory-safe") {
+            fmpBefore := mload(0x40)
+            for { let i := 0 } lt(i, POISON_WORDS) { i := add(i, 1) } {
+                mstore(add(fmpBefore, mul(i, 0x20)), add(0xF00D0000, i))
+            }
+        }
         uint256[] memory extended = LibUint256Array.unsafeExtend(base, extend);
         uint256 fmpAfter;
         assembly ("memory-safe") {
             fmpAfter := mload(0x40)
+            for { let i := 0 } lt(i, POISON_WORDS) { i := add(i, 1) } {
+                mstore(add(captured, mul(i, 0x20)), mload(add(fmpBefore, mul(i, 0x20))))
+            }
         }
-        _capture(captured, fmpBefore);
 
         assertEq(extended.length, 3, "length");
         assertEq(extended[2], 0x44);
@@ -149,13 +150,24 @@ contract LibUint256ArrayAllocationTest is Test {
         // Allocated after `base`, forcing the allocate-and-copy branch.
         uint256[] memory extend = new uint256[](0);
 
-        uint256 fmpBefore = _poisonFreeMemory();
+        // Poison, then the call under test, then snapshot and capture. The two
+        // assembly blocks sit flush against the call so the only boundary the
+        // poison crosses is the call being measured.
+        uint256 fmpBefore;
+        assembly ("memory-safe") {
+            fmpBefore := mload(0x40)
+            for { let i := 0 } lt(i, POISON_WORDS) { i := add(i, 1) } {
+                mstore(add(fmpBefore, mul(i, 0x20)), add(0xF00D0000, i))
+            }
+        }
         uint256[] memory extended = LibUint256Array.unsafeExtend(base, extend);
         uint256 fmpAfter;
         assembly ("memory-safe") {
             fmpAfter := mload(0x40)
+            for { let i := 0 } lt(i, POISON_WORDS) { i := add(i, 1) } {
+                mstore(add(captured, mul(i, 0x20)), mload(add(fmpBefore, mul(i, 0x20))))
+            }
         }
-        _capture(captured, fmpBefore);
 
         assertEq(extended.length, 2, "length");
         assertEq(extended[0], 0x11);

--- a/test/src/lib/LibUint256Array.allocation.t.sol
+++ b/test/src/lib/LibUint256Array.allocation.t.sol
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+
+import {LibUint256Array, Pointer} from "src/lib/LibUint256Array.sol";
+import {LibPointer} from "src/lib/LibPointer.sol";
+
+/// The existing `unsafeExtend` tests assert the CONTENTS of the extended array
+/// against a reference implementation. Contents alone cannot see the allocator
+/// invariants the assembly is responsible for: extending is free to
+/// over-allocate, or to write past the free memory pointer it just set, without
+/// any content assertion noticing. These tests pin those invariants down.
+///
+/// Every one of these tests must read the free memory pointer IMMEDIATELY after
+/// the call under test. Assertions allocate, so any assertion made first moves
+/// the free memory pointer and destroys the measurement.
+contract LibUint256ArrayAllocationTest is Test {
+    using LibUint256Array for uint256[];
+
+    /// Number of words of free memory poisoned above the free memory pointer.
+    uint256 internal constant POISON_WORDS = 8;
+
+    /// Poison `POISON_WORDS` words of FREE memory starting at the free memory
+    /// pointer with per-word recognisable sentinels. Returns the free memory
+    /// pointer as it stood before the call under test.
+    function _poisonFreeMemory() internal pure returns (uint256 fmpBefore) {
+        assembly ("memory-safe") {
+            fmpBefore := mload(0x40)
+            for { let i := 0 } lt(i, 8) { i := add(i, 1) } {
+                mstore(add(fmpBefore, mul(i, 0x20)), add(0xF00D0000, i))
+            }
+        }
+    }
+
+    /// Copy the poisoned region into `captured`, which the caller allocated
+    /// BEFORE poisoning so that it sits below the poisoned region and is itself
+    /// never disturbed. Copying must happen before any assertion runs.
+    function _capture(uint256[POISON_WORDS] memory captured, uint256 fmpBefore) internal pure {
+        assembly ("memory-safe") {
+            for { let i := 0 } lt(i, 8) { i := add(i, 1) } {
+                mstore(add(captured, mul(i, 0x20)), mload(add(fmpBefore, mul(i, 0x20))))
+            }
+        }
+    }
+
+    /// Every poisoned word that lies at or above the FINAL free memory pointer
+    /// is still free memory and must therefore be untouched.
+    function _assertNothingWrittenPastFmp(uint256[POISON_WORDS] memory captured, uint256 fmpBefore, uint256 fmpAfter)
+        internal
+        pure
+    {
+        for (uint256 i = 0; i < POISON_WORDS; i++) {
+            if (fmpBefore + i * 0x20 < fmpAfter) {
+                continue;
+            }
+            assertEq(captured[i], 0xF00D0000 + i, "wrote past the free memory pointer");
+        }
+    }
+
+    /// On the inline path the free memory pointer must end up EXACTLY at the
+    /// end of the extended array. Over-allocating here is invisible to every
+    /// content assertion but wastes memory and breaks the "base is the last
+    /// allocation" precondition that the next inline extension relies on.
+    function testExtendInlineAllocatesExactly() public pure {
+        uint256[] memory extend = new uint256[](2);
+        extend[0] = 0x44;
+        extend[1] = 0x55;
+
+        // Allocated last, so `base` is the most recent allocation and the
+        // inline branch is taken.
+        uint256[] memory base = new uint256[](3);
+        base[0] = 0x11;
+        base[1] = 0x22;
+        base[2] = 0x33;
+
+        uint256[] memory extended = LibUint256Array.unsafeExtend(base, extend);
+        uint256 fmpAfter = uint256(Pointer.unwrap(LibPointer.allocatedMemoryPointer()));
+        uint256 endOfExtended = uint256(Pointer.unwrap(extended.endPointer()));
+
+        assertEq(extended.length, 5, "length");
+        assertEq(extended[0], 0x11);
+        assertEq(extended[1], 0x22);
+        assertEq(extended[2], 0x33);
+        assertEq(extended[3], 0x44);
+        assertEq(extended[4], 0x55);
+        assertEq(fmpAfter, endOfExtended, "fmp must sit exactly at the end of the extended array");
+    }
+
+    /// Same invariant on the allocate-and-copy path, reached when the base
+    /// array is not the most recent allocation.
+    function testExtendAllocateAllocatesExactly() public pure {
+        uint256[] memory base = new uint256[](3);
+        base[0] = 0x11;
+        base[1] = 0x22;
+        base[2] = 0x33;
+
+        // Allocated after `base`, so `base` is no longer the last allocation.
+        uint256[] memory extend = new uint256[](2);
+        extend[0] = 0x44;
+        extend[1] = 0x55;
+
+        uint256[] memory extended = LibUint256Array.unsafeExtend(base, extend);
+        uint256 fmpAfter = uint256(Pointer.unwrap(LibPointer.allocatedMemoryPointer()));
+        uint256 endOfExtended = uint256(Pointer.unwrap(extended.endPointer()));
+
+        assertEq(extended.length, 5, "length");
+        assertEq(extended[0], 0x11);
+        assertEq(extended[4], 0x55);
+        assertEq(fmpAfter, endOfExtended, "fmp must sit exactly at the end of the extended array");
+    }
+
+    /// The inline path must not write above the free memory pointer it sets.
+    /// A copy that runs one word long lands on memory the allocator still
+    /// considers free, which the next allocation then hands out to someone else.
+    function testExtendInlineDoesNotWritePastFreeMemoryPointer() public pure {
+        uint256[POISON_WORDS] memory captured;
+
+        uint256[] memory extend = new uint256[](1);
+        extend[0] = 0x44;
+
+        uint256[] memory base = new uint256[](2);
+        base[0] = 0x11;
+        base[1] = 0x22;
+
+        uint256 fmpBefore = _poisonFreeMemory();
+        uint256[] memory extended = LibUint256Array.unsafeExtend(base, extend);
+        uint256 fmpAfter;
+        assembly ("memory-safe") {
+            fmpAfter := mload(0x40)
+        }
+        _capture(captured, fmpBefore);
+
+        assertEq(extended.length, 3, "length");
+        assertEq(extended[2], 0x44);
+        _assertNothingWrittenPastFmp(captured, fmpBefore, fmpAfter);
+    }
+
+    /// Same invariant on the allocate-and-copy path. An empty extend array is
+    /// used so that the extension copy cannot mask an over-long base copy.
+    function testExtendAllocateDoesNotWritePastFreeMemoryPointer() public pure {
+        uint256[POISON_WORDS] memory captured;
+
+        uint256[] memory base = new uint256[](2);
+        base[0] = 0x11;
+        base[1] = 0x22;
+
+        // Allocated after `base`, forcing the allocate-and-copy branch.
+        uint256[] memory extend = new uint256[](0);
+
+        uint256 fmpBefore = _poisonFreeMemory();
+        uint256[] memory extended = LibUint256Array.unsafeExtend(base, extend);
+        uint256 fmpAfter;
+        assembly ("memory-safe") {
+            fmpAfter := mload(0x40)
+        }
+        _capture(captured, fmpBefore);
+
+        assertEq(extended.length, 2, "length");
+        assertEq(extended[0], 0x11);
+        assertEq(extended[1], 0x22);
+        _assertNothingWrittenPastFmp(captured, fmpBefore, fmpAfter);
+    }
+}

--- a/test/src/lib/LibUint256Array.reverse.t.sol
+++ b/test/src/lib/LibUint256Array.reverse.t.sol
@@ -3,7 +3,8 @@
 pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
-import {LibUint256Array} from "src/lib/LibUint256Array.sol";
+import {LibUint256Array, Pointer} from "src/lib/LibUint256Array.sol";
+import {LibPointer} from "src/lib/LibPointer.sol";
 import {LibUint256ArraySlow} from "test/lib/LibUint256ArraySlow.sol";
 
 contract LibUint256ArrayReverseTest is Test {
@@ -14,7 +15,14 @@ contract LibUint256ArrayReverseTest is Test {
         for (uint256 i = 0; i < a.length; i++) {
             b[i] = a[i];
         }
+
+        // reverse is documented to mutate in place, so it must not move the
+        // free memory pointer at all. Read the pointer immediately either side
+        // of the call under test, as assertions themselves allocate.
+        Pointer allocatedBefore = LibPointer.allocatedMemoryPointer();
         LibUint256Array.reverse(a);
+        Pointer allocatedAfter = LibPointer.allocatedMemoryPointer();
+        assertEq(Pointer.unwrap(allocatedBefore), Pointer.unwrap(allocatedAfter), "reverse allocated");
 
         assertEq(a, LibUint256ArraySlow.reverseSlow(b));
     }

--- a/test/src/lib/LibUint256Array.truncate.t.sol
+++ b/test/src/lib/LibUint256Array.truncate.t.sol
@@ -3,7 +3,8 @@
 pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
-import {LibUint256Array} from "src/lib/LibUint256Array.sol";
+import {LibUint256Array, Pointer} from "src/lib/LibUint256Array.sol";
+import {LibPointer} from "src/lib/LibPointer.sol";
 import {OutOfBoundsTruncate} from "src/error/ErrUint256Array.sol";
 import {LibUint256ArraySlow} from "test/lib/LibUint256ArraySlow.sol";
 
@@ -21,7 +22,14 @@ contract LibUint256ArrayTruncateTest is Test {
         }
         assertEq(a, b);
 
+        // truncate is documented to mutate in place with "no new allocation or
+        // copying of data", so it must not move the free memory pointer. Read
+        // the pointer immediately either side of the call under test, as
+        // assertions themselves allocate.
+        Pointer allocatedBefore = LibPointer.allocatedMemoryPointer();
         LibUint256Array.truncate(a, newLength);
+        Pointer allocatedAfter = LibPointer.allocatedMemoryPointer();
+        assertEq(Pointer.unwrap(allocatedBefore), Pointer.unwrap(allocatedAfter), "truncate allocated");
 
         b = LibUint256ArraySlow.truncateSlow(b, newLength);
         assertEq(a, b);

--- a/test/src/lib/LibUint256Matrix.allocation.t.sol
+++ b/test/src/lib/LibUint256Matrix.allocation.t.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+
+import {LibUint256Array} from "src/lib/LibUint256Array.sol";
+import {LibUint256Matrix, LibPointer, Pointer} from "src/lib/LibUint256Matrix.sol";
+
+/// The existing `flatten` tests assert the CONTENTS of the flattened array.
+/// `flatten` also performs an allocation, and an over-allocating `flatten`
+/// passes every content assertion while leaving the free memory pointer beyond
+/// the end of the array it returned. `matrixFrom` and `arrayFrom` are already
+/// pinned to `allocatedMemoryPointer()`; `flatten` was not.
+contract LibUint256MatrixAllocationTest is Test {
+    using LibUint256Array for uint256[];
+    using LibUint256Matrix for uint256[][];
+
+    /// forge-config: default.fuzz.runs = 100
+    function testFlattenAllocatesExactly(uint256[][] memory matrix) external pure {
+        uint256[] memory flattened = matrix.flatten();
+
+        assertEq(
+            Pointer.unwrap(LibPointer.allocatedMemoryPointer()),
+            Pointer.unwrap(flattened.endPointer()),
+            "fmp must sit exactly at the end of the flattened array"
+        );
+    }
+
+    /// Concrete non-fuzzed case: a matrix of two non-empty arrays.
+    function testFlattenAllocatesExactlyConcrete() external pure {
+        uint256[][] memory matrix = new uint256[][](2);
+        matrix[0] = LibUint256Array.arrayFrom(0x81, 0x82);
+        matrix[1] = LibUint256Array.arrayFrom(0x83);
+
+        uint256[] memory flattened = matrix.flatten();
+        // Read the free memory pointer BEFORE any assertion, because assertions
+        // allocate and would move it.
+        uint256 fmpAfter = uint256(Pointer.unwrap(LibPointer.allocatedMemoryPointer()));
+        uint256 endOfFlattened = uint256(Pointer.unwrap(flattened.endPointer()));
+
+        assertEq(flattened.length, 3, "length");
+        assertEq(flattened[0], 0x81);
+        assertEq(flattened[1], 0x82);
+        assertEq(flattened[2], 0x83);
+        assertEq(fmpAfter, endOfFlattened, "fmp must sit exactly at the end of the flattened array");
+    }
+
+    /// An empty matrix must still allocate exactly the one length word.
+    function testFlattenEmptyAllocatesLengthWordOnly() external pure {
+        uint256[][] memory matrix = new uint256[][](0);
+
+        uint256 fmpBefore = uint256(Pointer.unwrap(LibPointer.allocatedMemoryPointer()));
+        uint256[] memory flattened = matrix.flatten();
+        uint256 fmpAfter = uint256(Pointer.unwrap(LibPointer.allocatedMemoryPointer()));
+
+        assertEq(flattened.length, 0, "length");
+        assertEq(fmpAfter - fmpBefore, 0x20, "exactly one length word allocated");
+    }
+}

--- a/test/src/lib/LibUint256Matrix.itemCount.t.sol
+++ b/test/src/lib/LibUint256Matrix.itemCount.t.sol
@@ -4,6 +4,7 @@ pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibUint256Matrix} from "src/lib/LibUint256Matrix.sol";
+import {LibPointer, Pointer} from "src/lib/LibPointer.sol";
 import {LibUint256MatrixSlow} from "test/lib/LibUint256MatrixSlow.sol";
 
 contract LibUint256MatrixItemCountTest is Test {
@@ -12,6 +13,14 @@ contract LibUint256MatrixItemCountTest is Test {
 
     /// forge-config: default.fuzz.runs = 100
     function testItemCountReference(uint256[][] memory matrix) external pure {
-        assertEq(matrix.itemCount(), matrix.itemCountSlow());
+        // itemCount only reads the matrix, so it must not move the free memory
+        // pointer. Read the pointer immediately either side of the call under
+        // test, as assertions themselves allocate.
+        Pointer allocatedBefore = LibPointer.allocatedMemoryPointer();
+        uint256 count = matrix.itemCount();
+        Pointer allocatedAfter = LibPointer.allocatedMemoryPointer();
+        assertEq(Pointer.unwrap(allocatedBefore), Pointer.unwrap(allocatedAfter), "itemCount allocated");
+
+        assertEq(count, matrix.itemCountSlow());
     }
 }


### PR DESCRIPTION
Refs #73

`LibUint256Array`/`LibUint256Matrix` are byte-for-byte identical to their bytes32 twins modulo the element type, but the uint256 suite asserted only array CONTENTS, never the allocator invariants the assembly is responsible for. An over-allocating or allocation-leaking uint256 path shipped green.

This adds the two missing allocation test files as mirrors of the bytes32 ones, and the three missing free memory pointer assertions:

- `test/src/lib/LibUint256Array.allocation.t.sol` (new, 4 tests) — pins `unsafeExtend`'s free memory pointer to the exact end of the extended array on both the inline and the allocate-and-copy path, and poisons free memory above the pointer to catch a copy that runs long.
- `test/src/lib/LibUint256Matrix.allocation.t.sol` (new, 3 tests) — pins `flatten`'s allocation, including that an empty matrix allocates exactly one length word.
- `truncate`, `reverse` and `itemCount` now assert they do not move the free memory pointer, matching their bytes32 counterparts.

No production code changes.

## QA
- Discriminating tests: `testExtendInlineAllocatesExactly`, `testExtendAllocateAllocatesExactly`, `testExtendInlineDoesNotWritePastFreeMemoryPointer`, `testExtendAllocateDoesNotWritePastFreeMemoryPointer`, `testFlattenAllocatesExactly`, `testFlattenAllocatesExactlyConcrete`, `testFlattenEmptyAllocatesLengthWordOnly`, plus the strengthened `testTruncate`, `testReverse`, `testItemCountReference` — each fails on base (every mutation below was applied to `src/`, `forge test --match-contract LibUint256` re-run, and ONLY the listed tests failed while the other 78 of the 80-test uint256 suite stayed green; each mutation was then reverted via `git checkout` and the tree confirmed clean)
- Mutations applied:
  - `LibUint256Array.unsafeExtend` inline `mstore(0x40, outputEnd)` -> `mstore(0x40, add(outputEnd, 0x20))` -> `testExtendInlineAllocatesExactly` ("fmp must sit exactly at the end of the extended array: 448 != 416") + `testExtendAllocateAllocatesExactly` ("576 != 544"); 78/80 still passed
  - `LibUint256Array.unsafeExtend` allocate branch `mcopy(newBase, base, newBaseSize)` -> `mcopy(newBase, base, add(newBaseSize, 0x20))` -> `testExtendAllocateDoesNotWritePastFreeMemoryPointer` ("wrote past the free memory pointer: 0 != 4027383811"); 79/80 still passed
  - `LibUint256Array.unsafeExtend` inline `mcopy(baseEnd, add(extend, 0x20), mul(extendLength, 0x20))` -> `mul(add(extendLength, 1), 0x20)` -> `testExtendInlineDoesNotWritePastFreeMemoryPointer` ("3 != 4027383809") + `testExtendAllocateDoesNotWritePastFreeMemoryPointer` ("2 != 4027383811")
  - `LibUint256Matrix.flatten` `mstore(0x40, add(array, add(0x20, mul(length, 0x20))))` -> `add(array, add(0x40, mul(length, 0x20)))` -> all three new tests (`testFlattenAllocatesExactly` "1604192 != 1604160", `testFlattenAllocatesExactlyConcrete` "544 != 512", `testFlattenEmptyAllocatesLengthWordOnly` "exactly one length word allocated: 64 != 32"); all 13 pre-existing `flatten` content tests survived it
  - `LibUint256Matrix.itemCount` + `mstore(0x40, add(mload(0x40), 0x20))` -> `testItemCountReference` ("itemCount allocated") + `testFlattenEmptyAllocatesLengthWordOnly`
  - `LibUint256Array.truncate` + `mstore(0x40, add(mload(0x40), 0x20))` -> `testTruncate` ("truncate allocated")
  - `LibUint256Array.reverse` + `mstore(0x40, add(mload(0x40), 0x20))` -> `testReverse` ("reverse allocated")
  - branch-reachability check: `mcopy(newBase, base, newBaseSize)` -> `mcopy(newBase, base, 0)` -> the `testExtendAllocate*` tests fail on `length`, proving they really do exercise the allocate-and-copy branch rather than a compiler-collapsed inline path (the NatSpec warns the optimizer may switch the caller between branches)
- Oracle: independent of the implementation. The poison canaries are sentinels the test itself writes (`0xF00D0000 + i`) and reads back, never values sourced from the library. The empty-`flatten` expectation (`0x20`) is the ABI memory layout of an empty array — one length word — not the allocator's own arithmetic. Element and length expectations are the concatenation/flattening of the literal inputs. The allocation-end expectation is `endPointer()`, computed from the RESULT array's own length word (what a consumer sees) and independently pinned by the pre-existing `testUint256ArrayEndPointer`.
- Category check: issue asks (1) `LibUint256Array` allocation tests, (2) `LibUint256Matrix` allocation tests, (3) `truncate` fmp assertion, (4) `reverse` fmp assertion, (5) `itemCount` fmp assertion, (6) raise the bytes32 `selfExtend` test to two canaries and a length-3 array, plus a structural anti-drift proposal. Covered 1,2,3,4,5 — the uint256 suite is now at full parity with the bytes32 suite, and I diffed all nine remaining test-file pairs (`arrayFrom`, `extend`, `pointer` x2, `flatten`, `matrixFrom`, and both `*Slow` reference libs) to confirm no further asymmetry exists. `Refs` not `Closes` because two named items are deliberately NOT in this diff: item 6 is mutation-saturated — re-introducing the exact pre-#57 aliasing regression (`mul(extendLength, 0x20)` -> `mul(mload(extend), 0x20)`) in `LibBytes32Array` is already killed by the existing single-canary `testSelfExtendBytes32WritesNothingAboveFreeMemoryPointer`, so a second canary would be a redundant test; and the structural half (collapsing the mirrored libraries, or an `abstract contract ArrayBehaviourTest` parameterised on virtual hooks) is a design question that should be settled by a human rather than decided inside a test-parity PR.

Co-Authored-By: Claude <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage verifying array extension allocates exactly the required memory and does not overwrite memory beyond the allocation boundary.
  * Added validation that matrix flattening allocates only the expected memory, including empty matrices.
  * Confirmed reverse, truncate, and item-count operations do not allocate additional memory.
  * Expanded checks for correct flattened contents and allocation-pointer consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->