### PR TITLE
[A02] refuse sentinel scans over word unaligned stack bounds

### DIFF
--- a/src/lib/LibStackSentinel.sol
+++ b/src/lib/LibStackSentinel.sol
@@ -3,13 +3,14 @@
 pragma solidity ^0.8.25;
 
 import {Pointer} from "./LibPointer.sol";
+import {UnalignedStackPointer} from "../error/ErrStackPointer.sol";
 
 /// Thrown when the sentinel tuple size is zero.
 error ZeroSentinelTupleSize();
 
 /// Thrown when the sentinel cannot be found. This can be because the sentinel
-/// was not in stack, but also if the upper pointer is below the lower, or the
-/// sentinel is in the stack but not aligned with the tuples size.
+/// was not in the stack, but also if the sentinel is in the stack but not
+/// aligned with the tuples size.
 /// @param sentinel The sentinel that was not found.
 error MissingSentinel(Sentinel sentinel);
 
@@ -101,7 +102,15 @@ library LibStackSentinel {
     /// attempts to loop from infinity. There is no explicit underflow check but
     /// there is no way to underflow without reverting due to gas.
     ///
-    /// @param upper Pointer to the top of the stack range.
+    /// The scan steps in whole words down from `upper`, so `lower` and `upper`
+    /// MUST be aligned WITH EACH OTHER to 32 bytes, i.e. the distance between
+    /// them MUST be a whole number of words. Neither pointer need be 32 byte
+    /// aligned in absolute terms, as a shared sub-word offset cancels out of
+    /// the distance. Pointers that are not word aligned with each other WILL
+    /// REVERT with `UnalignedStackPointer`.
+    ///
+    /// @param upper Pointer to the top of the stack range. MUST NOT be below
+    /// `lower` and MUST be a whole number of words above it.
     /// @param lower Pointer to the bottom of the stack range.
     /// @param sentinel The value to expect as the sentinel. MUST be present in
     /// the stack or `consumeSentinel` will revert. MUST NOT collide with valid
@@ -117,6 +126,16 @@ library LibStackSentinel {
     {
         if (n == 0) {
             revert ZeroSentinelTupleSize();
+        }
+        if (Pointer.unwrap(upper) < Pointer.unwrap(lower)) {
+            revert InvalidStackBounds(lower, upper);
+        }
+        // The scan steps in whole words down from `upper`, so an `upper` that
+        // is not a whole number of words above `lower` puts every probe and
+        // every tuple reference across the boundary of two of the caller's
+        // stack items.
+        if ((Pointer.unwrap(upper) - Pointer.unwrap(lower)) % 0x20 != 0) {
+            revert UnalignedStackPointer(lower, upper);
         }
 
         // Each tuple takes this much space in memory.
@@ -137,9 +156,6 @@ library LibStackSentinel {
 
         // We revert if the sentinel was not found.
         if (Pointer.unwrap(sentinelPointer) == 0) {
-            if (Pointer.unwrap(upper) < Pointer.unwrap(lower)) {
-                revert InvalidStackBounds(lower, upper);
-            }
             revert MissingSentinel(sentinel);
         }
 

--- a/test/src/lib/LibStackSentinel.t.sol
+++ b/test/src/lib/LibStackSentinel.t.sol
@@ -6,6 +6,7 @@ import {Test} from "forge-std-1.16.1/src/Test.sol";
 
 import {LibPointer, Pointer} from "src/lib/LibPointer.sol";
 import {LibUint256Array} from "src/lib/LibStackPointer.sol";
+import {UnalignedStackPointer} from "src/error/ErrStackPointer.sol";
 import {
     LibStackSentinel,
     Sentinel,
@@ -235,19 +236,121 @@ contract LibStackSentinelTest is Test {
         (tuplesPointer);
     }
 
-    function testConsumeSentinelTuplesUnderflowError(Pointer lower, Pointer upper, Sentinel sentinel, uint256 n)
-        public
-    {
+    function testConsumeSentinelTuplesUnderflowError(Pointer lower, uint8 words, Sentinel sentinel, uint256 n) public {
         // If the sentinel is easy to collide with then it might just match and
         // not underflow, which defeats the purpose of the test.
         vm.assume(Sentinel.unwrap(sentinel) > type(uint128).max);
         vm.assume(Pointer.unwrap(lower) < n);
-        vm.assume(Pointer.unwrap(upper) > Pointer.unwrap(lower));
+        vm.assume(words > 0);
+        // `upper` is a whole number of words above `lower` so the scan runs
+        // rather than being refused as unaligned.
+        uint256 distance = uint256(words) * 0x20;
+        vm.assume(Pointer.unwrap(lower) <= type(uint256).max - distance);
+        Pointer upper = Pointer.wrap(Pointer.unwrap(lower) + distance);
 
         // Underflow will revert because it will run out of gas attempting to
         // loop over infinity.
         vm.expectRevert();
         this.consumeSentinelTuplesExternal(lower, upper, sentinel, n);
+    }
+
+    /// Two pointers that are not a whole number of words apart cannot describe
+    /// a stack of words, so the scan is refused.
+    function testConsumeSentinelTuplesUnalignedError(
+        Pointer lower,
+        uint8 words,
+        uint8 offsetSeed,
+        Sentinel sentinel,
+        uint256 n
+    ) public {
+        vm.assume(n > 0);
+        // Any sub word distance between the two pointers.
+        uint256 distance = (uint256(words) * 0x20) + ((uint256(offsetSeed) % 0x1f) + 1);
+        vm.assume(Pointer.unwrap(lower) <= type(uint256).max - distance);
+        Pointer upper = Pointer.wrap(Pointer.unwrap(lower) + distance);
+
+        vm.expectRevert(abi.encodeWithSelector(UnalignedStackPointer.selector, lower, upper));
+        this.consumeSentinelTuplesExternal(lower, upper, sentinel, n);
+    }
+
+    /// Lays out real memory such that the word stepped scan down from an
+    /// unaligned `upper` steps over the whole stack and lands on a sentinel
+    /// sitting below `lower`.
+    function consumeSentinelTuplesBelowLowerExternal(Sentinel sentinel) external pure returns (Pointer, Pointer) {
+        Pointer lower;
+        Pointer upper;
+        assembly ("memory-safe") {
+            let base := mload(0x40)
+            mstore(0x40, add(base, 0x100))
+            lower := add(base, 0x20)
+            // 0x30 is not a whole number of words.
+            upper := add(lower, 0x30)
+            // Zero the two words that are actually in the stack so nothing in
+            // range and nothing straddling them can match the sentinel.
+            mstore(lower, 0)
+            mstore(add(lower, 0x20), 0)
+            // The sentinel sits half a word below the bottom of the stack,
+            // exactly where the second probe of the scan reads.
+            mstore(sub(lower, 0x10), sentinel)
+        }
+        return lower.consumeSentinelTuples(upper, sentinel, 1);
+    }
+
+    function testConsumeSentinelTuplesBelowLower(Sentinel sentinel) external view {
+        vm.assume(Sentinel.unwrap(sentinel) != 0);
+
+        (bool success, bytes memory data) =
+            address(this).staticcall(abi.encodeCall(this.consumeSentinelTuplesBelowLowerExternal, (sentinel)));
+
+        assertFalse(success);
+        assertEq(data.length, 4 + 0x40);
+        bytes4 selector;
+        uint256 lower;
+        uint256 upper;
+        assembly ("memory-safe") {
+            selector := mload(add(data, 0x20))
+            lower := mload(add(data, 0x24))
+            upper := mload(add(data, 0x44))
+        }
+        assertEq(selector, UnalignedStackPointer.selector);
+        assertEq(upper - lower, 0x30);
+    }
+
+    /// Neither pointer needs to be aligned in absolute terms, only with each
+    /// other, so a sub word offset shared by both pointers builds tuples as
+    /// normal.
+    function testConsumeSentinelTuplesSharedSubWordOffset(
+        Sentinel sentinel,
+        uint8 offsetSeed,
+        uint256 item0,
+        uint256 item1
+    ) external pure {
+        vm.assume(Sentinel.unwrap(sentinel) != item0);
+        vm.assume(Sentinel.unwrap(sentinel) != item1);
+        uint256 offset = (uint256(offsetSeed) % 0x1f) + 1;
+
+        Pointer lower;
+        assembly ("memory-safe") {
+            let base := mload(0x40)
+            mstore(0x40, add(base, 0x100))
+            lower := add(base, offset)
+            mstore(lower, sentinel)
+            mstore(add(lower, 0x20), item0)
+            mstore(add(lower, 0x40), item1)
+        }
+
+        (Pointer sentinelPointer, Pointer tuplesPointer) =
+            lower.consumeSentinelTuples(lower.unsafeAddWords(3), sentinel, 1);
+
+        assertEq(Pointer.unwrap(sentinelPointer), Pointer.unwrap(lower));
+        assertEq(tuplesPointer.unsafeReadWord(), bytes32(uint256(2)));
+
+        uint256[1][] memory tuples;
+        assembly ("memory-safe") {
+            tuples := tuplesPointer
+        }
+        assertEq(tuples[0][0], item0);
+        assertEq(tuples[1][0], item1);
     }
 
     function testConsumeSentinelTuplesInitialStateUnderflowError(Pointer lower, Pointer upper, Sentinel sentinel)

--- a/test/src/lib/LibStackSentinel.t.sol
+++ b/test/src/lib/LibStackSentinel.t.sol
@@ -35,6 +35,24 @@ contract LibStackSentinelTest is Test {
         this.externalConsumeSentinelTuplesStack(stack, sentinel, 0);
     }
 
+    /// A zero tuple size is reported ahead of anything that is wrong with the
+    /// bounds.
+    function testConsumeSentinelTuplesNZeroErrorPrecedence(
+        Pointer upper,
+        uint8 words,
+        uint8 offsetSeed,
+        Sentinel sentinel
+    ) external {
+        // `lower` is above `upper` AND not a whole number of words from it, so
+        // both of the pointer guards would fire too.
+        uint256 distance = (uint256(words) * 0x20) + ((uint256(offsetSeed) % 0x1f) + 1);
+        vm.assume(Pointer.unwrap(upper) <= type(uint256).max - distance);
+        Pointer lower = Pointer.wrap(Pointer.unwrap(upper) + distance);
+
+        vm.expectRevert(abi.encodeWithSelector(ZeroSentinelTupleSize.selector));
+        this.consumeSentinelTuplesExternal(lower, upper, sentinel, 0);
+    }
+
     function testConsumeSentinelTuplesMultiSize(
         uint256[] memory stack,
         Sentinel sentinel,


### PR DESCRIPTION
Closes #64

`LibStackSentinel.consumeSentinelTuples` steps its scan cursor down from `upper` in whole words (`upper - j*size`) while the loop guard is `gt(cursor, lower)` and the probe reads at `cursor - 0x20`. That is only safe when `lower` and `upper` are a whole number of words apart. When they are not, `cursor` lands in the open interval `(lower, lower + 0x20)` and the probe reads up to 31 bytes **below** `lower` — so the sentinel can be matched outside the declared stack, `sentinelPointer` can be returned below `lower`, and every tuple reference pass 2 writes is offset from the caller's word grid, making each 32 byte "struct field" a bit-spliced composite of two adjacent stack words. The function returns successfully with fabricated values.

This adds the missing guard, reusing the `UnalignedStackPointer` error and the same "aligned WITH EACH OTHER" convention already established by `LibStackPointer.toIndexSigned`. Alignment is mutual, not absolute: a sub-word offset shared by both pointers cancels out of the distance and is still accepted.

`InvalidStackBounds` is hoisted ahead of the scan so the subtraction cannot underflow and the bounds error no longer depends on the not-found path, which simplifies to a plain `MissingSentinel`.

## QA
- Discriminating tests: `testConsumeSentinelTuplesUnalignedError`, `testConsumeSentinelTuplesBelowLower` — each fails on base (verified by re-deleting the guard, mutation M5, which restores `main`'s exact code: `Suite result: FAILED. 16 passed; 2 failed` and the two failures are precisely these tests). `testConsumeSentinelTuplesSharedSubWordOffset` and `testConsumeSentinelTuplesNZeroErrorPrecedence` pass on base by construction — they pin behaviour this change newly makes reachable, and are proven discriminating against mutations M7/M8 and M16 respectively.
- Mutations applied: 18 probes, whole suite run per probe, source restored via VCS each time (`git diff --stat` empty, verified). `if (n == 0)` → `if (false)` → killed by `testConsumeSentinelTuplesNZeroError`; `if (upper < lower)` → `if (false)` → killed by `testConsumeSentinelTuplesInitialStateUnderflowError`; bounds `<` → `<=` → killed by `testConsumeSentinelTuplesEmptyError` (+1); `InvalidStackBounds(lower, upper)` → `(upper, lower)` → killed by `testConsumeSentinelTuplesInitialStateUnderflowError`; alignment guard deleted (= `main`) → killed by `testConsumeSentinelTuplesUnalignedError` + `testConsumeSentinelTuplesBelowLower`; alignment condition negated → killed (15 tests); `(upper - lower) % 0x20` → `upper % 0x20` → killed by `testConsumeSentinelTuplesSharedSubWordOffset` + `testConsumeSentinelTuplesUnalignedError`; → `lower % 0x20` → killed (3 tests); `UnalignedStackPointer(lower, upper)` → `(upper, lower)` → killed by both new revert tests; `% 0x20` → `% 0x40` → killed (12 tests); `revert MissingSentinel(sentinel)` → `revert ZeroSentinelTupleSize()` → killed by `testConsumeSentinelTuplesMissingSentinel`, `...EmptyError`, `...OddSentinel`; alignment guard hoisted above the bounds guard → killed by `testConsumeSentinelTuplesInitialStateUnderflowError`; alignment guard moved below the scan → killed by `testConsumeSentinelTuplesUnalignedError`; scan guard `gt(cursor, lower)` → `gt(cursor, add(lower, 0x20))` → killed (10 tests); pass 2 guard `lt(cursor, upper)` → `lt(cursor, sub(upper, 0x20))` → killed (3 tests); `% 0x20` → `% (n * 0x20)` (tuple-granularity instead of word-granularity) → killed (12 tests); `% 0x20 != 0` → `% 0x20 > 0x10` → killed by both new revert tests. One survivor: moving `if (n == 0)` below both pointer guards survived the whole suite — the current output (`ZeroSentinelTupleSize` wins, matching `main`, where it was the only pre-scan guard) was checked against intent and is correct, so it was pinned by the new `testConsumeSentinelTuplesNZeroErrorPrecedence`, which then kills that mutation (`18 passed; 1 failed`).
- Oracle: the alignment rule is derived independently of this implementation, from the sibling `LibStackPointer.toIndexSigned` NatSpec ("aligned WITH EACH OTHER to 32 bytes... Neither pointer need be 32 byte aligned in absolute terms") and its `UnalignedStackPointer` error, plus the arithmetic invariant that all cursors are congruent to `upper` mod `0x20` so `cursor > lower` implies `cursor - 0x20 >= lower` only when `upper ≡ lower (mod 0x20)`. `testConsumeSentinelTuplesBelowLower` lays out real memory with the sentinel deliberately placed at `lower - 0x10` — the address the second probe of an unaligned scan actually reads — rather than asserting anything the implementation computes. `testConsumeSentinelTuplesSharedSubWordOffset` asserts the tuple values against the words the test itself wrote, not against anything read back from the library.
- Category check: issue asks for (A) the missing mutual word-alignment check reusing `UnalignedStackPointer`, (B) hoisting `InvalidStackBounds` ahead of the scan, (C) simplifying the not-found branch to a plain `MissingSentinel`; covered A, B, C. The issue's `lower = 0x100, upper = 0x130, n = 1` worked example is one instance of the category — the new fuzz test covers every sub-word offset `1..31` at every word distance, and the concrete test covers the "sentinel matched below the declared stack bottom" consequence with real memory.

Co-Authored-By: Claude <noreply@anthropic.com>
