### PR TITLE
test(flatten): pin the empty-inner-array boundary deterministically

### DIFF
--- a/test/src/lib/LibBytes32Matrix.flatten.t.sol
+++ b/test/src/lib/LibBytes32Matrix.flatten.t.sol
@@ -146,6 +146,135 @@ contract LibBytes32MatrixFlattenTest is Test {
         checkFlatten(matrix, expected);
     }
 
+    /// An empty inner array contributes nothing, so it must not advance the
+    /// write cursor. That is only observable when a NON-EMPTY inner array
+    /// follows the empty one. Every concrete case above either makes every
+    /// inner array empty or puts the empty one LAST, so this is the first case
+    /// where a spurious cursor advance on an empty inner array displaces data.
+    function testFlattenEmptyFirstThenNonEmpty() external pure {
+        bytes32[][] memory matrix = new bytes32[][](2);
+        matrix[0] = new bytes32[](0);
+        matrix[1] = new bytes32[](2);
+        matrix[1][0] = bytes32(uint256(0x11));
+        matrix[1][1] = bytes32(uint256(0x22));
+
+        bytes32[] memory expected = new bytes32[](2);
+        expected[0] = bytes32(uint256(0x11));
+        expected[1] = bytes32(uint256(0x22));
+        checkFlatten(matrix, expected);
+    }
+
+    /// A leading inner array that was never assigned is also empty, but it is
+    /// the zero slot rather than a freshly allocated length word. It must
+    /// behave the same as an explicitly allocated empty array.
+    function testFlattenUninitialisedFirstThenNonEmpty() external pure {
+        bytes32[][] memory matrix = new bytes32[][](2);
+        matrix[1] = new bytes32[](2);
+        matrix[1][0] = bytes32(uint256(0x11));
+        matrix[1][1] = bytes32(uint256(0x22));
+
+        bytes32[] memory expected = new bytes32[](2);
+        expected[0] = bytes32(uint256(0x11));
+        expected[1] = bytes32(uint256(0x22));
+        checkFlatten(matrix, expected);
+    }
+
+    /// An empty inner array in an INTERIOR position must not displace the
+    /// elements that follow it.
+    function testFlattenEmptyInteriorBetweenNonEmpty() external pure {
+        bytes32[][] memory matrix = new bytes32[][](3);
+        matrix[0] = new bytes32[](1);
+        matrix[0][0] = bytes32(uint256(0x11));
+        matrix[1] = new bytes32[](0);
+        matrix[2] = new bytes32[](2);
+        matrix[2][0] = bytes32(uint256(0x22));
+        matrix[2][1] = bytes32(uint256(0x33));
+
+        bytes32[] memory expected = new bytes32[](3);
+        expected[0] = bytes32(uint256(0x11));
+        expected[1] = bytes32(uint256(0x22));
+        expected[2] = bytes32(uint256(0x33));
+        checkFlatten(matrix, expected);
+    }
+
+    /// A RUN of empty inner arrays between two non-empty ones. Each empty array
+    /// is handled by its own iteration of the copy loop, so a per-iteration
+    /// displacement accumulates across the run.
+    function testFlattenConsecutiveEmptyInterior() external pure {
+        bytes32[][] memory matrix = new bytes32[][](4);
+        matrix[0] = new bytes32[](1);
+        matrix[0][0] = bytes32(uint256(0x11));
+        matrix[1] = new bytes32[](0);
+        matrix[2] = new bytes32[](0);
+        matrix[3] = new bytes32[](1);
+        matrix[3][0] = bytes32(uint256(0x22));
+
+        bytes32[] memory expected = new bytes32[](2);
+        expected[0] = bytes32(uint256(0x11));
+        expected[1] = bytes32(uint256(0x22));
+        checkFlatten(matrix, expected);
+    }
+
+    /// A run of empty inner arrays in the LEADING position, before any data has
+    /// been written at all.
+    function testFlattenMultipleEmptyLeading() external pure {
+        bytes32[][] memory matrix = new bytes32[][](3);
+        matrix[0] = new bytes32[](0);
+        matrix[1] = new bytes32[](0);
+        matrix[2] = new bytes32[](2);
+        matrix[2][0] = bytes32(uint256(0x11));
+        matrix[2][1] = bytes32(uint256(0x22));
+
+        bytes32[] memory expected = new bytes32[](2);
+        expected[0] = bytes32(uint256(0x11));
+        expected[1] = bytes32(uint256(0x22));
+        checkFlatten(matrix, expected);
+    }
+
+    /// Empty inner arrays occupying the first, an interior and the last
+    /// position of the same matrix.
+    function testFlattenEmptyFirstInteriorAndLast() external pure {
+        bytes32[][] memory matrix = new bytes32[][](5);
+        matrix[0] = new bytes32[](0);
+        matrix[1] = new bytes32[](1);
+        matrix[1][0] = bytes32(uint256(0x11));
+        matrix[2] = new bytes32[](0);
+        matrix[3] = new bytes32[](1);
+        matrix[3][0] = bytes32(uint256(0x22));
+        matrix[4] = new bytes32[](0);
+
+        bytes32[] memory expected = new bytes32[](2);
+        expected[0] = bytes32(uint256(0x11));
+        expected[1] = bytes32(uint256(0x22));
+        checkFlatten(matrix, expected);
+    }
+
+    /// Sweep the POSITION of a single empty inner array across every index of
+    /// every outer length up to 6, deterministically. No position of an empty
+    /// inner array is left to a fuzzer to stumble upon.
+    function testFlattenSingleEmptyAtEveryPosition() external pure {
+        for (uint256 outerLength = 1; outerLength <= 6; outerLength++) {
+            for (uint256 emptyAt = 0; emptyAt < outerLength; emptyAt++) {
+                bytes32[][] memory matrix = new bytes32[][](outerLength);
+                bytes32[] memory expected = new bytes32[]((outerLength - 1) * 2);
+                uint256 k = 0;
+                for (uint256 i = 0; i < outerLength; i++) {
+                    if (i == emptyAt) {
+                        matrix[i] = new bytes32[](0);
+                        continue;
+                    }
+                    matrix[i] = new bytes32[](2);
+                    matrix[i][0] = bytes32((i * 2) + 1);
+                    matrix[i][1] = bytes32((i * 2) + 2);
+                    expected[k] = bytes32((i * 2) + 1);
+                    expected[k + 1] = bytes32((i * 2) + 2);
+                    k += 2;
+                }
+                checkFlatten(matrix, expected);
+            }
+        }
+    }
+
     /// forge-config: default.fuzz.runs = 100
     function testFlattenReference(bytes32[][] memory matrix) external pure {
         checkFlatten(matrix, LibBytes32MatrixSlow.flattenSlow(matrix));

--- a/test/src/lib/LibUint256Matrix.flatten.t.sol
+++ b/test/src/lib/LibUint256Matrix.flatten.t.sol
@@ -146,6 +146,135 @@ contract LibUint256MatrixFlattenTest is Test {
         checkFlatten(matrix, expected);
     }
 
+    /// An empty inner array contributes nothing, so it must not advance the
+    /// write cursor. That is only observable when a NON-EMPTY inner array
+    /// follows the empty one. Every concrete case above either makes every
+    /// inner array empty or puts the empty one LAST, so this is the first case
+    /// where a spurious cursor advance on an empty inner array displaces data.
+    function testFlattenEmptyFirstThenNonEmpty() external pure {
+        uint256[][] memory matrix = new uint256[][](2);
+        matrix[0] = new uint256[](0);
+        matrix[1] = new uint256[](2);
+        matrix[1][0] = 0x11;
+        matrix[1][1] = 0x22;
+
+        uint256[] memory expected = new uint256[](2);
+        expected[0] = 0x11;
+        expected[1] = 0x22;
+        checkFlatten(matrix, expected);
+    }
+
+    /// A leading inner array that was never assigned is also empty, but it is
+    /// the zero slot rather than a freshly allocated length word. It must
+    /// behave the same as an explicitly allocated empty array.
+    function testFlattenUninitialisedFirstThenNonEmpty() external pure {
+        uint256[][] memory matrix = new uint256[][](2);
+        matrix[1] = new uint256[](2);
+        matrix[1][0] = 0x11;
+        matrix[1][1] = 0x22;
+
+        uint256[] memory expected = new uint256[](2);
+        expected[0] = 0x11;
+        expected[1] = 0x22;
+        checkFlatten(matrix, expected);
+    }
+
+    /// An empty inner array in an INTERIOR position must not displace the
+    /// elements that follow it.
+    function testFlattenEmptyInteriorBetweenNonEmpty() external pure {
+        uint256[][] memory matrix = new uint256[][](3);
+        matrix[0] = new uint256[](1);
+        matrix[0][0] = 0x11;
+        matrix[1] = new uint256[](0);
+        matrix[2] = new uint256[](2);
+        matrix[2][0] = 0x22;
+        matrix[2][1] = 0x33;
+
+        uint256[] memory expected = new uint256[](3);
+        expected[0] = 0x11;
+        expected[1] = 0x22;
+        expected[2] = 0x33;
+        checkFlatten(matrix, expected);
+    }
+
+    /// A RUN of empty inner arrays between two non-empty ones. Each empty array
+    /// is handled by its own iteration of the copy loop, so a per-iteration
+    /// displacement accumulates across the run.
+    function testFlattenConsecutiveEmptyInterior() external pure {
+        uint256[][] memory matrix = new uint256[][](4);
+        matrix[0] = new uint256[](1);
+        matrix[0][0] = 0x11;
+        matrix[1] = new uint256[](0);
+        matrix[2] = new uint256[](0);
+        matrix[3] = new uint256[](1);
+        matrix[3][0] = 0x22;
+
+        uint256[] memory expected = new uint256[](2);
+        expected[0] = 0x11;
+        expected[1] = 0x22;
+        checkFlatten(matrix, expected);
+    }
+
+    /// A run of empty inner arrays in the LEADING position, before any data has
+    /// been written at all.
+    function testFlattenMultipleEmptyLeading() external pure {
+        uint256[][] memory matrix = new uint256[][](3);
+        matrix[0] = new uint256[](0);
+        matrix[1] = new uint256[](0);
+        matrix[2] = new uint256[](2);
+        matrix[2][0] = 0x11;
+        matrix[2][1] = 0x22;
+
+        uint256[] memory expected = new uint256[](2);
+        expected[0] = 0x11;
+        expected[1] = 0x22;
+        checkFlatten(matrix, expected);
+    }
+
+    /// Empty inner arrays occupying the first, an interior and the last
+    /// position of the same matrix.
+    function testFlattenEmptyFirstInteriorAndLast() external pure {
+        uint256[][] memory matrix = new uint256[][](5);
+        matrix[0] = new uint256[](0);
+        matrix[1] = new uint256[](1);
+        matrix[1][0] = 0x11;
+        matrix[2] = new uint256[](0);
+        matrix[3] = new uint256[](1);
+        matrix[3][0] = 0x22;
+        matrix[4] = new uint256[](0);
+
+        uint256[] memory expected = new uint256[](2);
+        expected[0] = 0x11;
+        expected[1] = 0x22;
+        checkFlatten(matrix, expected);
+    }
+
+    /// Sweep the POSITION of a single empty inner array across every index of
+    /// every outer length up to 6, deterministically. No position of an empty
+    /// inner array is left to a fuzzer to stumble upon.
+    function testFlattenSingleEmptyAtEveryPosition() external pure {
+        for (uint256 outerLength = 1; outerLength <= 6; outerLength++) {
+            for (uint256 emptyAt = 0; emptyAt < outerLength; emptyAt++) {
+                uint256[][] memory matrix = new uint256[][](outerLength);
+                uint256[] memory expected = new uint256[]((outerLength - 1) * 2);
+                uint256 k = 0;
+                for (uint256 i = 0; i < outerLength; i++) {
+                    if (i == emptyAt) {
+                        matrix[i] = new uint256[](0);
+                        continue;
+                    }
+                    matrix[i] = new uint256[](2);
+                    matrix[i][0] = (i * 2) + 1;
+                    matrix[i][1] = (i * 2) + 2;
+                    expected[k] = (i * 2) + 1;
+                    expected[k + 1] = (i * 2) + 2;
+                    k += 2;
+                }
+                checkFlatten(matrix, expected);
+            }
+        }
+    }
+
     /// forge-config: default.fuzz.runs = 100
     function testFlattenReference(uint256[][] memory matrix) external pure {
         checkFlatten(matrix, LibUint256MatrixSlow.flattenSlow(matrix));


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.solmem/issues/68

`flatten`'s copy loop advances the write cursor by the inner array's size, which is zero for an empty inner array (`src/lib/LibUint256Matrix.sol:141`). Whether an empty inner array correctly contributes nothing to the destination cursor is only observable when a NON-EMPTY inner array FOLLOWS it.

Every pre-existing concrete case either makes every inner array empty or puts the empty one LAST, so a write-cursor bug at an empty-array boundary was reachable only through the 100-run differential fuzz.

This adds deterministic cases for every empty-array boundary position, in both `test/src/lib/LibUint256Matrix.flatten.t.sol` and its bytes32 twin:

- `testFlattenEmptyFirstThenNonEmpty` — leading empty.
- `testFlattenUninitialisedFirstThenNonEmpty` — leading empty that is the zero slot rather than an allocated length word.
- `testFlattenEmptyInteriorBetweenNonEmpty` — interior empty.
- `testFlattenConsecutiveEmptyInterior` — a run of interior empties.
- `testFlattenMultipleEmptyLeading` — a run of leading empties.
- `testFlattenEmptyFirstInteriorAndLast` — first, interior and last empties in one matrix.
- `testFlattenSingleEmptyAtEveryPosition` — a deterministic sweep of one empty across every index of every outer length 1..6.

No production code changes. No existing test was weakened, loosened or deleted.

## QA
- Discriminating tests: `testFlattenEmptyFirstThenNonEmpty`, `testFlattenUninitialisedFirstThenNonEmpty`, `testFlattenEmptyInteriorBetweenNonEmpty`, `testFlattenConsecutiveEmptyInterior`, `testFlattenMultipleEmptyLeading`, `testFlattenEmptyFirstInteriorAndLast`, `testFlattenSingleEmptyAtEveryPosition` (all 7 in both the uint256 and the bytes32 suite) — each fails on base (the tests were committed first, then each mutation below was applied to `src/`, `forge test --match-path 'test/src/lib/*Matrix.flatten.t.sol' --fuzz-seed 1` re-run, the failing set recorded, and the mutation reverted with `git checkout -- src/` with `git status --porcelain` confirmed empty each time)
- Mutations applied:
  - `LibUint256Matrix.sol:141` + `LibBytes32Matrix.sol:141` `arrayCursor := add(arrayCursor, size)` -> `arrayCursor := add(arrayCursor, add(size, mul(0x20, iszero(size))))` (an empty inner array spuriously advances the write cursor by one word) -> ALL 12 pre-existing concrete `testFlatten*` cases PASSED in both suites (24 passed, 16 failed of 40); killed by all 7 new tests in both suites — uint256 messages: `testFlattenEmptyFirstThenNonEmpty` "0 != 17", `testFlattenUninitialisedFirstThenNonEmpty` "0 != 17", `testFlattenEmptyInteriorBetweenNonEmpty` "0 != 34", `testFlattenConsecutiveEmptyInterior` "0 != 34", `testFlattenMultipleEmptyLeading` "0 != 17", `testFlattenEmptyFirstInteriorAndLast` "0 != 17", `testFlattenSingleEmptyAtEveryPosition` "0 != 3" — plus `testFlattenReference` at seed 1
  - same two lines -> `arrayCursor := sub(add(arrayCursor, size), mul(0x20, iszero(size)))` (an empty inner array rewinds the cursor instead) -> again ALL 12 pre-existing concrete cases PASSED (12 passed, 8 failed of 20 in the uint256 suite); killed by all 7 new tests — `testFlattenEmptyFirstThenNonEmpty` "length: 17 != 2", `testFlattenUninitialisedFirstThenNonEmpty` "length: 17 != 2", `testFlattenEmptyInteriorBetweenNonEmpty` "34 != 17", `testFlattenConsecutiveEmptyInterior` "length: 34 != 2", `testFlattenMultipleEmptyLeading` "length: 34 != 2", `testFlattenEmptyFirstInteriorAndLast` "length: 34 != 2", `testFlattenSingleEmptyAtEveryPosition` "length: 3 != 2"
  - `LibUint256Matrix.sol:141` `arrayCursor := add(arrayCursor, size)` -> `arrayCursor := add(arrayCursor, 0x20)` (advance one word regardless of size) -> killed by the PRE-EXISTING `testFlatten211` ("3 != 2"): existing coverage of the non-empty cursor advance validated, no new test needed for it
  - `LibUint256Matrix.sol:140` `mcopy(arrayCursor, add(mload(cursor), 0x20), size)` -> `mcopy(arrayCursor, mload(cursor), size)` (copy from the inner length word) -> killed by the PRE-EXISTING `testFlatten12`, `testFlatten121`, `testFlatten211`, `testFlatten22`, `testFlatten23`: existing coverage of the copy source validated
- Oracle: independent of the implementation. Every expected array in the new tests is a hand-written literal concatenation of the literal inputs (`0x11`, `0x22`, `0x33`, and `i*2+1`/`i*2+2` in the position sweep) derived from the NatSpec contract that `flatten` returns the ordered concatenation of the inner arrays with length equal to the sum of the inner lengths — never a value read back from the assembly. The pre-existing `testFlattenReference` cross-checks the same behaviour against `LibUint256MatrixSlow.flattenSlow`, a plain-Solidity reference with bounds-checked indexing that shares no code with the assembly.
- Category check: issue asks for a deterministic case with an empty inner array somewhere other than last, naming leading and interior as examples and proposing a position fuzz. Covered the whole category deterministically — leading (allocated and zero-slot), interior, consecutive interior, multiple leading, first+interior+last in one matrix, and an exhaustive deterministic sweep of a single empty across every index of every outer length 1..6 (which supersedes the proposed 100-run position fuzz rather than leaving any position to chance) — mirrored into the bytes32 twin. `Closes` because every position class the issue describes is now pinned by a deterministic test.
