### PR TITLE
test(extend): pin which unsafeExtend branch each test executes

### DIFF
--- a/test/src/lib/LibBytes32Array.extend.t.sol
+++ b/test/src/lib/LibBytes32Array.extend.t.sol
@@ -4,33 +4,85 @@ pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 
-import {LibBytes32Array} from "src/lib/LibBytes32Array.sol";
+import {LibBytes32Array, Pointer} from "src/lib/LibBytes32Array.sol";
 import {LibBytes32ArraySlow} from "test/lib/LibBytes32ArraySlow.sol";
 
 contract LibBytes32ArrayExtendTest is Test {
     // This code path hits the inline extension by ensuring that c is the most
-    // recent thing allocated.
+    // recent thing allocated. Both code paths produce identical contents, so
+    // the returned pointer is the only thing that says which one ran: the
+    // inline path extends the base in place and returns the pointer it was
+    // given.
     /// forge-config: default.fuzz.runs = 100
     function testExtendInline(bytes32[] memory a, bytes32[] memory b) public pure {
         bytes32[] memory c = new bytes32[](a.length);
         for (uint256 i = 0; i < a.length; i++) {
             c[i] = a[i];
         }
+        uint256 cBefore = Pointer.unwrap(LibBytes32Array.startPointer(c));
         c = LibBytes32Array.unsafeExtend(c, b);
+        assertEq(cBefore, Pointer.unwrap(LibBytes32Array.startPointer(c)), "inline path not taken");
 
         assertEq(c, LibBytes32ArraySlow.extendSlow(a, b));
     }
 
     // This code path hits extension with allocation due to b sitting behind c.
+    // The allocating path copies the base to a fresh allocation, so it returns
+    // a pointer that differs from the one it was given.
     /// forge-config: default.fuzz.runs = 100
     function testExtendAllocate(bytes32[] memory a, bytes32[] memory b) public pure {
         bytes32[] memory c = new bytes32[](b.length);
         for (uint256 i = 0; i < b.length; i++) {
             c[i] = b[i];
         }
+        uint256 bBefore = Pointer.unwrap(LibBytes32Array.startPointer(b));
         b = LibBytes32Array.unsafeExtend(b, a);
+        assertNotEq(bBefore, Pointer.unwrap(LibBytes32Array.startPointer(b)), "allocate path not taken");
 
         assertEq(b, LibBytes32ArraySlow.extendSlow(c, a));
+    }
+
+    /// Extending by an EMPTY array copies nothing, so both code paths leave
+    /// byte-identical contents behind and contents cannot say which one ran.
+    /// The contents are asserted FIRST here precisely because they hold on
+    /// either path: the returned pointer is the only discriminator, and the
+    /// inline path returns the pointer it was given.
+    function testExtendInlineEmptyExtendKeepsBasePointer() public pure {
+        bytes32[] memory extend = new bytes32[](0);
+
+        // Allocated last, so base is the most recent allocation.
+        bytes32[] memory base = new bytes32[](2);
+        base[0] = bytes32(uint256(0x11));
+        base[1] = bytes32(uint256(0x22));
+
+        uint256 baseBefore = Pointer.unwrap(LibBytes32Array.startPointer(base));
+        bytes32[] memory extended = LibBytes32Array.unsafeExtend(base, extend);
+
+        assertEq(extended.length, 2, "length");
+        assertEq(extended[0], bytes32(uint256(0x11)), "0");
+        assertEq(extended[1], bytes32(uint256(0x22)), "1");
+        assertEq(baseBefore, Pointer.unwrap(LibBytes32Array.startPointer(extended)), "inline path not taken");
+    }
+
+    /// The allocating counterpart of the case above. Same contents, and the
+    /// allocating path copies the base to a fresh allocation so it returns a
+    /// pointer that differs from the one it was given.
+    function testExtendAllocateEmptyExtendMovesBasePointer() public pure {
+        bytes32[] memory base = new bytes32[](2);
+        base[0] = bytes32(uint256(0x11));
+        base[1] = bytes32(uint256(0x22));
+
+        // Allocated after base, so base is no longer the most recent
+        // allocation.
+        bytes32[] memory extend = new bytes32[](0);
+
+        uint256 baseBefore = Pointer.unwrap(LibBytes32Array.startPointer(base));
+        bytes32[] memory extended = LibBytes32Array.unsafeExtend(base, extend);
+
+        assertEq(extended.length, 2, "length");
+        assertEq(extended[0], bytes32(uint256(0x11)), "0");
+        assertEq(extended[1], bytes32(uint256(0x22)), "1");
+        assertNotEq(baseBefore, Pointer.unwrap(LibBytes32Array.startPointer(extended)), "allocate path not taken");
     }
 
     function testExtendAllocateDebug() public pure {

--- a/test/src/lib/LibUint256Array.extend.t.sol
+++ b/test/src/lib/LibUint256Array.extend.t.sol
@@ -4,33 +4,85 @@ pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 
-import {LibUint256Array} from "src/lib/LibUint256Array.sol";
+import {LibUint256Array, Pointer} from "src/lib/LibUint256Array.sol";
 import {LibUint256ArraySlow} from "test/lib/LibUint256ArraySlow.sol";
 
 contract LibUint256ArrayExtendTest is Test {
     // This code path hits the inline extension by ensuring that c is the most
-    // recent thing allocated.
+    // recent thing allocated. Both code paths produce identical contents, so
+    // the returned pointer is the only thing that says which one ran: the
+    // inline path extends the base in place and returns the pointer it was
+    // given.
     /// forge-config: default.fuzz.runs = 100
     function testExtendInline(uint256[] memory a, uint256[] memory b) public pure {
         uint256[] memory c = new uint256[](a.length);
         for (uint256 i = 0; i < a.length; i++) {
             c[i] = a[i];
         }
+        uint256 cBefore = Pointer.unwrap(LibUint256Array.startPointer(c));
         c = LibUint256Array.unsafeExtend(c, b);
+        assertEq(cBefore, Pointer.unwrap(LibUint256Array.startPointer(c)), "inline path not taken");
 
         assertEq(c, LibUint256ArraySlow.extendSlow(a, b));
     }
 
     // This code path hits extension with allocation due to b sitting behind c.
+    // The allocating path copies the base to a fresh allocation, so it returns
+    // a pointer that differs from the one it was given.
     /// forge-config: default.fuzz.runs = 100
     function testExtendAllocate(uint256[] memory a, uint256[] memory b) public pure {
         uint256[] memory c = new uint256[](b.length);
         for (uint256 i = 0; i < b.length; i++) {
             c[i] = b[i];
         }
+        uint256 bBefore = Pointer.unwrap(LibUint256Array.startPointer(b));
         b = LibUint256Array.unsafeExtend(b, a);
+        assertNotEq(bBefore, Pointer.unwrap(LibUint256Array.startPointer(b)), "allocate path not taken");
 
         assertEq(b, LibUint256ArraySlow.extendSlow(c, a));
+    }
+
+    /// Extending by an EMPTY array copies nothing, so both code paths leave
+    /// byte-identical contents behind and contents cannot say which one ran.
+    /// The contents are asserted FIRST here precisely because they hold on
+    /// either path: the returned pointer is the only discriminator, and the
+    /// inline path returns the pointer it was given.
+    function testExtendInlineEmptyExtendKeepsBasePointer() public pure {
+        uint256[] memory extend = new uint256[](0);
+
+        // Allocated last, so base is the most recent allocation.
+        uint256[] memory base = new uint256[](2);
+        base[0] = 0x11;
+        base[1] = 0x22;
+
+        uint256 baseBefore = Pointer.unwrap(LibUint256Array.startPointer(base));
+        uint256[] memory extended = LibUint256Array.unsafeExtend(base, extend);
+
+        assertEq(extended.length, 2, "length");
+        assertEq(extended[0], 0x11, "0");
+        assertEq(extended[1], 0x22, "1");
+        assertEq(baseBefore, Pointer.unwrap(LibUint256Array.startPointer(extended)), "inline path not taken");
+    }
+
+    /// The allocating counterpart of the case above. Same contents, and the
+    /// allocating path copies the base to a fresh allocation so it returns a
+    /// pointer that differs from the one it was given.
+    function testExtendAllocateEmptyExtendMovesBasePointer() public pure {
+        uint256[] memory base = new uint256[](2);
+        base[0] = 0x11;
+        base[1] = 0x22;
+
+        // Allocated after base, so base is no longer the most recent
+        // allocation.
+        uint256[] memory extend = new uint256[](0);
+
+        uint256 baseBefore = Pointer.unwrap(LibUint256Array.startPointer(base));
+        uint256[] memory extended = LibUint256Array.unsafeExtend(base, extend);
+
+        assertEq(extended.length, 2, "length");
+        assertEq(extended[0], 0x11, "0");
+        assertEq(extended[1], 0x22, "1");
+        assertNotEq(baseBefore, Pointer.unwrap(LibUint256Array.startPointer(extended)), "allocate path not taken");
     }
 
     function testExtendAllocateDebug() public pure {


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.solmem/issues/69

`unsafeExtend` has two code paths and the existing tests name one each in a comment, but neither asserted anything that discriminates them — both only compared contents against `extendSlow`, and both paths produce identical contents.

The branch is observable through the returned pointer: the inline path extends the base in place and returns the pointer it was given, the allocate-and-copy path copies the base to a fresh allocation and returns a different one.

- `testExtendInline` and `testExtendAllocate` are STRENGTHENED IN PLACE in both `test/src/lib/LibUint256Array.extend.t.sol` and its bytes32 twin so each asserts the pointer identity its comment claims. `testExtendAllocateDebug` inherits the assertion through `testExtendAllocate`.
- Two deterministic cases per file are added that extend by an EMPTY array. That is the shape where both paths leave byte-identical contents behind, so the returned pointer is the ONLY discriminator; their content assertions deliberately run first so a failure at the pin proves the contents were correct.

No production code changes. No existing test was weakened, loosened or deleted.

## QA
- Discriminating tests: `testExtendInline`, `testExtendAllocate`, `testExtendInlineEmptyExtendKeepsBasePointer`, `testExtendAllocateEmptyExtendMovesBasePointer` (all four in both the uint256 and the bytes32 file), plus `testExtendAllocateDebug` which inherits the assertion — each fails on base (the tests were committed as c01060d first, then each mutation below was applied to `src/`, `forge test --match-path 'test/src/lib/*Array.extend.t.sol' --fuzz-seed 1` re-run, the failing set recorded, and the mutation reverted with `git checkout` and `git status --porcelain` confirmed empty each time; each mutation was additionally re-run against `origin/main`'s version of the two test files to see what the unstrengthened suite reports)
- Mutations applied:
  - `LibUint256Array.sol:336` + `LibBytes32Array.sol:336` `switch eq(outputCursor, baseEnd)` -> `switch 1` (force the inline branch, so the allocating branch becomes dead code) -> killed by `testExtendAllocate` ("allocate path not taken: 4096 == 4096"), `testExtendAllocateDebug` ("allocate path not taken: 256 == 256") and `testExtendAllocateEmptyExtendMovesBasePointer` ("allocate path not taken: 128 == 128") in both suites; `testExtendInline` and `testExtendInlineEmptyExtendKeepsBasePointer` correctly survive it. Against `origin/main`'s tests the SAME mutation reports `panic: memory allocation error (0x41)` and a mismatch against a garbage 100+ element array — it says nothing about the branch, and main has no empty-extend case at all.
  - `LibUint256Array.sol:332` + `LibBytes32Array.sol:332` `let baseEnd := add(base, add(0x20, mul(baseLength, 0x20)))` -> `add(base, add(0x40, mul(baseLength, 0x20)))` (the off-by-one in `baseEnd` the issue names, which flips which branch each precondition selects) -> killed by `testExtendInline` ("inline path not taken: 7616 != 11584"), `testExtendInlineEmptyExtendKeepsBasePointer` ("inline path not taken: 160 != 256") and `testExtendAllocateEmptyExtendMovesBasePointer` ("allocate path not taken: 128 == 128") in both suites. The two empty-extend tests fail AT THE PIN, which forge only reaches after their `length` and per-element assertions have already passed — the contents are correct under this mutation and the pointer is the only thing that sees it. Against `origin/main`'s tests the same mutation only produces garbage-array content mismatches.
  - branch-reachability sanity check: under `switch 1` the two inline-claiming tests stay green and only the allocate-claiming ones fail, and under the `baseEnd` off-by-one the inline-claiming ones fail — so the two preconditions really do select different branches rather than the compiler collapsing them (the NatSpec warns the optimizer may switch the caller between branches).
- Oracle: independent of the implementation. The branch expectation comes from the `unsafeExtend` NatSpec contract — "the base array IS MUTATED DIRECTLY by some code paths AND THE FINAL RETURN ARRAY MAY POINT TO THE SAME REGION OF MEMORY", i.e. extending in place returns the same region and copying returns a different one — not from any value read back from the assembly. The pointer values themselves are captured with `startPointer` before and after the call and only ever compared to each other, never to a hardcoded address. Contents continue to be checked against `LibUint256ArraySlow.extendSlow` / literal inputs.
- Category check: issue asks for (a) `testExtendInline` to pin the inline branch, (b) `testExtendAllocate` to pin the allocating branch, (c) the same in the mirrored `LibBytes32Array.extend.t.sol`. Covered a, b, c — strengthened in place rather than duplicated, in both files, and extended past the literal examples with a deterministic empty-extend case per branch, which is the shape where contents are byte-identical across the branches and the pin is the only possible discriminator. `Closes` because every branch-claiming test in the two files the issue names now asserts its branch.
