### PR TITLE
Refuse to consume a sentinel stack that lies above the allocated memory pointer

### DIFF
--- a/src/lib/LibStackSentinel.sol
+++ b/src/lib/LibStackSentinel.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity ^0.8.25;
 
-import {Pointer} from "./LibPointer.sol";
+import {LibPointer, Pointer} from "./LibPointer.sol";
 
 /// Thrown when the sentinel tuple size is zero.
 error ZeroSentinelTupleSize();
@@ -18,6 +18,12 @@ error MissingSentinel(Sentinel sentinel);
 /// @param lower The lower stack pointer.
 /// @param upper The upper stack pointer.
 error InvalidStackBounds(Pointer lower, Pointer upper);
+
+/// Thrown when the top of the stack is above the allocated memory pointer, so
+/// the tuples array cannot be built without overwriting the stack it describes.
+/// @param upper The upper stack pointer.
+/// @param allocated The allocated memory pointer.
+error UnallocatedStack(Pointer upper, Pointer allocated);
 
 /// > In computer programming, a sentinel value (also referred to as a flag
 /// > value, trip value, rogue value, signal value, or dummy data)[1] is a
@@ -101,7 +107,17 @@ library LibStackSentinel {
     /// attempts to loop from infinity. There is no explicit underflow check but
     /// there is no way to underflow without reverting due to gas.
     ///
-    /// @param upper Pointer to the top of the stack range.
+    /// The tuples array is allocated at the allocated memory pointer and grows
+    /// upward from there, so a stack that extends above the allocated memory
+    /// pointer would be overwritten by the very array that references it. The
+    /// stack therefore MUST be within allocated memory. A stack that extends
+    /// above the allocated memory pointer and contains the sentinel WILL REVERT
+    /// with `UnallocatedStack`. The search for the sentinel only reads memory,
+    /// so the same stack without the sentinel in it reverts with
+    /// `MissingSentinel` instead.
+    ///
+    /// @param upper Pointer to the top of the stack range. MUST NOT be above
+    /// the allocated memory pointer.
     /// @param lower Pointer to the bottom of the stack range.
     /// @param sentinel The value to expect as the sentinel. MUST be present in
     /// the stack or `consumeSentinel` will revert. MUST NOT collide with valid
@@ -141,6 +157,16 @@ library LibStackSentinel {
                 revert InvalidStackBounds(lower, upper);
             }
             revert MissingSentinel(sentinel);
+        }
+
+        // The tuples array is allocated at the allocated memory pointer and
+        // grows upward, so a stack above the allocated memory pointer is
+        // overlapped and overwritten by the array that references it.
+        {
+            Pointer allocated = LibPointer.allocatedMemoryPointer();
+            if (Pointer.unwrap(upper) > Pointer.unwrap(allocated)) {
+                revert UnallocatedStack(upper, allocated);
+            }
         }
 
         // Second pass to build references _in order_ from the sentinel back up

--- a/test/src/lib/LibStackSentinel.t.sol
+++ b/test/src/lib/LibStackSentinel.t.sol
@@ -11,7 +11,8 @@ import {
     Sentinel,
     MissingSentinel,
     ZeroSentinelTupleSize,
-    InvalidStackBounds
+    InvalidStackBounds,
+    UnallocatedStack
 } from "src/lib/LibStackSentinel.sol";
 
 contract LibStackSentinelTest is Test {
@@ -280,8 +281,16 @@ contract LibStackSentinelTest is Test {
         Pointer lower;
         assembly ("memory-safe") {
             lower := mload(0x40)
+            // Allocate the one word stack so that it sits at or below the
+            // allocated memory pointer.
+            mstore(0x40, add(lower, 0x20))
             mstore(lower, sentinel)
         }
+
+        // The tuples array MUST be allocated exactly at the free memory
+        // pointer, i.e. with no gap between the prior allocation and the
+        // length slot of the tuples array.
+        Pointer expectedTuplesPointer = LibPointer.allocatedMemoryPointer();
 
         (Pointer sentinelPointer, Pointer tuplesPointer) =
             lower.consumeSentinelTuples(lower.unsafeAddWord(), sentinel, 2);
@@ -289,8 +298,85 @@ contract LibStackSentinelTest is Test {
         assertEq(tuplesPointer.unsafeReadWord(), 0);
         // A zero length tuples array is still allocated exactly at the free
         // memory pointer, and consumes exactly one word for its length.
-        assertEq(Pointer.unwrap(tuplesPointer), Pointer.unwrap(lower));
+        assertEq(Pointer.unwrap(tuplesPointer), Pointer.unwrap(expectedTuplesPointer));
         assertEq(Pointer.unwrap(LibPointer.allocatedMemoryPointer()), Pointer.unwrap(tuplesPointer.unsafeAddWord()));
+        // The stack is left intact because the tuples array is built above it.
+        assertEq(lower.unsafeReadWord(), bytes32(Sentinel.unwrap(sentinel)));
+    }
+
+    /// Stages a stack at the allocated memory pointer WITHOUT allocating it,
+    /// exactly as a caller building a temporary structure above the free memory
+    /// pointer would. `consume` false reports the pointers that were staged
+    /// without consuming them. Both variants decode the same static argument
+    /// types so both see the same allocated memory pointer.
+    function consumeSentinelTuplesUnallocatedExternal(Sentinel sentinel, uint256 words, bool consume)
+        external
+        pure
+        returns (Pointer upper, Pointer allocated)
+    {
+        Pointer lower;
+        assembly ("memory-safe") {
+            allocated := mload(0x40)
+            lower := allocated
+            upper := add(lower, mul(words, 0x20))
+            mstore(lower, sentinel)
+        }
+        if (consume) {
+            (Pointer sentinelPointer, Pointer tuplesPointer) = lower.consumeSentinelTuples(upper, sentinel, 2);
+            (sentinelPointer);
+            (tuplesPointer);
+        }
+    }
+
+    /// A stack above the allocated memory pointer is where the tuples array
+    /// that describes it would be built, so consuming it would overwrite it.
+    /// This is refused rather than returning a well formed array of corrupt
+    /// references.
+    function testConsumeSentinelTuplesUnallocatedStackError(Sentinel sentinel, uint8 tupleCount) external {
+        // An odd number of words puts the sentinel at the bottom of the stack
+        // in alignment with the 2 item tuples above it.
+        uint256 words = (uint256(tupleCount) % 8) * 2 + 1;
+
+        (Pointer upper, Pointer allocated) = this.consumeSentinelTuplesUnallocatedExternal(sentinel, words, false);
+        assertEq(Pointer.unwrap(upper), Pointer.unwrap(allocated) + words * 0x20);
+
+        vm.expectRevert(abi.encodeWithSelector(UnallocatedStack.selector, upper, allocated));
+        this.consumeSentinelTuplesUnallocatedExternal(sentinel, words, true);
+    }
+
+    /// A stack that ends exactly at the allocated memory pointer is entirely
+    /// within allocated memory, so it is consumed and the tuples array is built
+    /// directly above it, leaving the stack it references intact.
+    function testConsumeSentinelTuplesUpperAtAllocated(Sentinel sentinel, uint256 item0, uint256 item1) external pure {
+        vm.assume(Sentinel.unwrap(sentinel) != item0);
+        vm.assume(Sentinel.unwrap(sentinel) != item1);
+
+        Pointer lower;
+        assembly ("memory-safe") {
+            lower := mload(0x40)
+            mstore(0x40, add(lower, 0x60))
+            mstore(lower, sentinel)
+            mstore(add(lower, 0x20), item0)
+            mstore(add(lower, 0x40), item1)
+        }
+        Pointer upper = lower.unsafeAddWords(3);
+        assertEq(Pointer.unwrap(upper), Pointer.unwrap(LibPointer.allocatedMemoryPointer()));
+
+        (Pointer sentinelPointer, Pointer tuplesPointer) = lower.consumeSentinelTuples(upper, sentinel, 2);
+        assertEq(Pointer.unwrap(sentinelPointer), Pointer.unwrap(lower));
+        assertEq(Pointer.unwrap(tuplesPointer), Pointer.unwrap(upper));
+
+        uint256[2][] memory tuples;
+        assembly ("memory-safe") {
+            tuples := tuplesPointer
+        }
+        assertEq(tuples.length, 1);
+        assertEq(tuples[0][0], item0);
+        assertEq(tuples[0][1], item1);
+        // The stack is left intact because the tuples array is built above it.
+        assertEq(lower.unsafeReadWord(), bytes32(Sentinel.unwrap(sentinel)));
+        assertEq(lower.unsafeAddWord().unsafeReadWord(), bytes32(item0));
+        assertEq(lower.unsafeAddWords(2).unsafeReadWord(), bytes32(item1));
     }
 
     function testConsumeSentinelTuplesGas0() external pure {
@@ -300,6 +386,9 @@ contract LibStackSentinelTest is Test {
         assembly ("memory-safe") {
             lower := mload(0x40)
             upper := add(lower, 0x20)
+            // Allocate the stack so that it sits at or below the allocated
+            // memory pointer.
+            mstore(0x40, upper)
             mstore(lower, sentinel)
         }
         (Pointer sentinelPointer, Pointer tuplesPointer) = lower.consumeSentinelTuples(upper, sentinel, 2);
@@ -314,6 +403,9 @@ contract LibStackSentinelTest is Test {
         assembly ("memory-safe") {
             lower := mload(0x40)
             upper := add(lower, 0x60)
+            // Allocate the stack so that it sits at or below the allocated
+            // memory pointer.
+            mstore(0x40, upper)
             mstore(lower, sentinel)
         }
         (Pointer sentinelPointer, Pointer tuplesPointer) = lower.consumeSentinelTuples(upper, sentinel, 2);
@@ -328,6 +420,9 @@ contract LibStackSentinelTest is Test {
         assembly ("memory-safe") {
             lower := mload(0x40)
             upper := add(lower, 0xa0)
+            // Allocate the stack so that it sits at or below the allocated
+            // memory pointer.
+            mstore(0x40, upper)
             mstore(lower, sentinel)
         }
         (Pointer sentinelPointer, Pointer tuplesPointer) = lower.consumeSentinelTuples(upper, sentinel, 2);
@@ -342,6 +437,9 @@ contract LibStackSentinelTest is Test {
         assembly ("memory-safe") {
             lower := mload(0x40)
             upper := add(lower, 0xe0)
+            // Allocate the stack so that it sits at or below the allocated
+            // memory pointer.
+            mstore(0x40, upper)
             mstore(lower, sentinel)
         }
         (Pointer sentinelPointer, Pointer tuplesPointer) = lower.consumeSentinelTuples(upper, sentinel, 2);

--- a/test/src/lib/LibStackSentinel.t.sol
+++ b/test/src/lib/LibStackSentinel.t.sol
@@ -344,6 +344,34 @@ contract LibStackSentinelTest is Test {
         this.consumeSentinelTuplesUnallocatedExternal(sentinel, words, true);
     }
 
+    /// Stages a stack above the allocated memory pointer and leaves it as the
+    /// untouched (therefore zero) memory it already is, so it cannot contain a
+    /// non zero sentinel.
+    function consumeSentinelTuplesUnallocatedMissingExternal(Sentinel sentinel) external pure {
+        Pointer lower;
+        Pointer upper;
+        assembly ("memory-safe") {
+            lower := mload(0x40)
+            upper := add(lower, 0x60)
+        }
+        (Pointer sentinelPointer, Pointer tuplesPointer) = lower.consumeSentinelTuples(upper, sentinel, 2);
+        (sentinelPointer);
+        (tuplesPointer);
+    }
+
+    /// The search for the sentinel only reads memory, so a stack above the
+    /// allocated memory pointer with no sentinel in it is reported as a missing
+    /// sentinel. Nothing is allocated on that path so there is nothing to
+    /// overwrite.
+    function testConsumeSentinelTuplesUnallocatedMissingSentinel(Sentinel sentinel) external {
+        // A zero sentinel would be found in the untouched memory the stack
+        // sits in.
+        vm.assume(Sentinel.unwrap(sentinel) != 0);
+
+        vm.expectRevert(abi.encodeWithSelector(MissingSentinel.selector, sentinel));
+        this.consumeSentinelTuplesUnallocatedMissingExternal(sentinel);
+    }
+
     /// A stack that ends exactly at the allocated memory pointer is entirely
     /// within allocated memory, so it is consumed and the tuples array is built
     /// directly above it, leaving the stack it references intact.


### PR DESCRIPTION
Closes #63

`LibStackSentinel.consumeSentinelTuples` builds the tuples array at the
allocated memory pointer and grows it upward. Nothing constrained the
caller-supplied `[lower, upper)` stack relative to that pointer, so a stack whose
`upper` sits above it was overwritten by the very array that references it, and
the call returned a well formed array of corrupt references rather than
reverting.

## The fix

Before allocating, read the allocated memory pointer and revert
`UnallocatedStack(upper, allocated)` when `upper` is above it.

The check sits at the allocation site rather than at the top of the function.
`consumeSentinelTuples` guards in this order:

1. `ZeroSentinelTupleSize` — a zero tuple size, ahead of every pointer guard.
2. `InvalidStackBounds` — `upper` is below `lower`.
3. `UnalignedStackPointer` — `upper` is not a whole number of words above
   `lower`.
4. First pass: the search for the sentinel, which only reads memory.
5. `MissingSentinel` — the search found nothing.
6. `UnallocatedStack` — this change.
7. Second pass: allocate at the allocated memory pointer and build the tuples
   array.

2 and 3 came from #106 and belong above the scan: 2 so that the subtraction in 3
cannot underflow, 3 so that the word-stepped scan cannot step across the
boundary of the caller's stack items. 6 belongs below the scan for the opposite
reason. The search only reads memory, so nothing it is given can be corrupted
until an allocation is actually about to happen, and reverting earlier would
narrow what the library can report:

- A stack above the allocated memory pointer with no sentinel in it still
  reports `MissingSentinel`. Hoisting the guard above the scan turns that into
  `UnallocatedStack`, which is what `testConsumeSentinelTuplesUnallocatedMissingSentinel`
  kills the hoist mutation on.
- An underflowing scan still dies from gas exhaustion rather than being
  answered with a pointer error, because `testConsumeSentinelTuplesUnderflowError`
  fuzzes `lower` freely and its stack is almost always above the free memory
  pointer.

Only the previously-corrupting successes change behaviour.

`upper == allocated` is accepted: the stack ends exactly where the tuples array
begins, so the two regions are disjoint. The bound is otherwise conservative on
purpose — a stack outside allocated memory is not a valid input under Solidity's
memory model, where anything at or above the free memory pointer is scratch that
any allocation may clobber.

The gas fixtures and the empty case staged their stacks at the free memory
pointer without advancing it, and so relied on the overlapping allocation. They
now allocate the region they stage.

The real consumer, `LibFlow.stackToFlow` in rainlanguage/flow, is unaffected: it
chains three calls whose `upper` is the previous call's `sentinelPointer`, which
is strictly below the previous call's tuples array and therefore below the free
memory pointer.

## QA
- Discriminating tests: `testConsumeSentinelTuplesUnallocatedStackError`, `testConsumeSentinelTuplesUpperAtAllocated`, `testConsumeSentinelTuplesUnallocatedMissingSentinel`, plus the strengthened `testConsumeSentinelTuplesEmpty` (now asserts the staged sentinel word survives the call). None of them compiles against base, because `UnallocatedStack` does not exist there, so each was instead verified against a mutation that restores the base behaviour in place.
- Mutations, re-run against the merged tree from a committed baseline at `324 passed; 0 failed`, one at a time, each restored with `git checkout --` to a verified-empty `git status --porcelain` and each recompiled (`Compiler run successful!`) so the mutation was live in the bytecode under test: delete the whole guard block → `323 passed; 1 failed`, killed by `testConsumeSentinelTuplesUnallocatedStackError`; `>` → `>=` → `314 passed; 10 failed`, killed by `testConsumeSentinelTuplesUpperAtAllocated` plus `testConsumeSentinelTuples`, `testConsumeSentinelTuples3`, `testConsumeSentinelTuplesEmpty`, `testConsumeSentinelTuplesMultiple`, `testConsumeSentinelTuplesMultiSize` and `testConsumeSentinelTuplesGas0..3`; hoist the guard above the sentinel search → `323 passed; 1 failed`, killed by `testConsumeSentinelTuplesUnallocatedMissingSentinel`. The two guards this branch merged in from #106 were probed on the same tree: delete the alignment guard → `322 passed; 2 failed`, killed by `testConsumeSentinelTuplesUnalignedError` and `testConsumeSentinelTuplesBelowLower`; delete the hoisted `InvalidStackBounds` → `323 passed; 1 failed`, killed by `testConsumeSentinelTuplesInitialStateUnderflowError`. Zero survivors.
- Oracle: Solidity's memory model, not the implementation. `[tuplesPointer, tuplesPointer + (count + 1) * 0x20)` must be disjoint from the caller's `[lower, upper)`; since `tuplesPointer` is the allocated memory pointer and the array grows upward, disjointness holds exactly when `upper <= mload(0x40)`. `testConsumeSentinelTuplesUpperAtAllocated` and `testConsumeSentinelTuplesEmpty` stage their own stack words and assert those exact values survive the call, so the expected values come from what the test wrote, never from what the library returned. `testConsumeSentinelTuplesUnallocatedStackError` derives its expected revert payload from a non-consuming call to the same helper with the same static argument types, so `(upper, allocated)` are the pointers the fixture itself staged.
- Every pointer this branch stages is a whole number of words above `lower`, so #106's alignment guard never preempts one of these tests, and `testConsumeSentinelTuplesSharedSubWordOffset` stages its stack well below the free memory pointer, so this branch's guard never preempts that one.
- Category check: the issue asks for the category "the tuples array is allocated at the free memory pointer with no check that the stack lies below it", illustrated with `testConsumeSentinelTuplesGas1` and `testConsumeSentinelTuplesEmpty`; covered the whole category — the guard applies to every caller-supplied `upper`, and `Gas0`, `Gas2` and `Gas3` were converted to allocate what they stage alongside the two fixtures the issue names. The issue's fallback (a NatSpec line stating the precondition) is also done, in addition to the runtime guard rather than instead of it. The issue's suggestion to reuse `InvalidStackBounds` was not followed: that error's NatSpec means "lower is above upper", so reusing it would make the discriminant ambiguous for consumers; a distinct `UnallocatedStack` carrying `upper` and the allocated memory pointer is used instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent processing stack data outside allocated memory.
  * Operations now revert with a clear error when the stack exceeds the allocated memory boundary.
  * Improved handling of empty tuples and stacks ending exactly at the allocated boundary.

* **Tests**
  * Added coverage for unallocated stacks, missing sentinels, and boundary conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->