### PR TITLE
Run rainix CI on pull_request so fork PRs get checks

### DIFF
--- a/.github/workflows/rainix.yaml
+++ b/.github/workflows/rainix.yaml
@@ -1,5 +1,13 @@
 name: rainix
-on: [push]
+# `pull_request` is what gives a fork's PR any checks at all: a fork's push
+# event fires in the fork, not here, so a push-only trigger leaves an external
+# PR with an empty checks list. `push` stays for main so a direct push or a
+# merge is still judged, and is branch-scoped so a same-repo PR branch runs
+# this workflow once rather than twice.
+on:
+  push:
+    branches: [main]
+  pull_request:
 jobs:
   rainix:
     uses: rainlanguage/rainix/.github/workflows/rainix-sol.yaml@main


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.solmem/issues/90

## What changed

`.github/workflows/rainix.yaml` gains a `pull_request` trigger and scopes
`push` to `main`.

A fork's `push` event fires in the fork, not here, so with `on: [push]` an
external PR arrives with an empty checks list — no `forge test`, no `slither`,
no `forge fmt --check`, no `reuse lint`. `README.md` invites outside
contributions, `main` has no branch protection
(`GET /repos/rainlanguage/rain.solmem/branches/main/protection` → 404 "Branch
not protected", `/rulesets` → `[]`), and `package-release.yaml` auto-publishes
an immutable soldeer revision on every push to `main`. So an unchecked external
merge goes straight to a published release.

Branch-scoping `push` to `main` means a same-repo PR branch is judged once by
`pull_request` instead of twice; direct pushes and merges to `main` are still
judged.

## Premise re-verified against live main

`on: [push]` was still there on `e8cb007`. Every one of the last 20 workflow
runs on this repo has `event: push`; there is not a single `pull_request` run
in the history.

## Fork PRs will not red on missing secrets

`secrets: inherit` hands a fork PR nothing, so the three ramifications were
checked against the rainix reusables at `main`:

- `nix-cachix-setup` documents an empty `cachix-auth-token` as "degrades to a
  read-only/anonymous Cachix pull", and its `cachix-action` step is
  `continue-on-error: true`.
- `rpc-preflight` probes "only networks the repo actually references";
  `foundry.toml` here has no `[rpc_endpoints]`, and `grep` finds no
  `createFork`/`createSelectFork` anywhere in `src/` or `test/` — this repo has
  no fork tests.
- `rainix-sol-static` / `rainix-sol-legal` use no secrets beyond Cachix.

## Verification

CI-config only; no Solidity touched, so the suite count does not move.

- `forge test` — 34 suites, **350 passed, 0 failed, 0 skipped**, before and after.
- `forge fmt --check` — exit 0.
- `reuse lint` — compliant, 70/70 files.
- `slither .` — 9 contracts, 99 detectors, **0 results**.
- `yq '.on'` on the new file parses to
  `{"push":{"branches":["main"]},"pull_request":null}`.
- `pre-commit` `yamlfmt` passed on commit.

## QA

- **Discriminating tests:** n/a as `forge` tests — the diff is a GitHub Actions
  trigger, not Solidity, and no unit test can observe which event GitHub
  dispatches. The discriminating check is the event stream itself, taken from
  live GitHub. On base (`on: [push]`): the last 20 runs on this repo are 20/20
  `event: push`, 8 of them on non-`main` PR branches, and **0** are
  `event: pull_request`. On this head:
  `gh run list --branch 2026-08-17-issue-90-ci-pull-request-trigger` returned
  **empty** after the push, and the only run on this PR is
  `event: pull_request` — the same event a fork PR fires in this repo. Fails on
  base, passes on head.
- **Mutations applied:** none to code — the diff contains no Solidity and the
  suite is byte-identical at 350 passed / 0 failed / 0 skipped either side.
  Each clause of the trigger was falsified separately against that live event
  stream instead: removing `pull_request` *is* base, whose 0-of-20
  `pull_request` runs is the observed failure; removing `push.branches: [main]`
  *is* base, whose 8-of-20 non-`main` branch-push runs are the double-run this
  avoids — the empty run list above is what its presence produced.
- **Oracle:** GitHub's event model (a fork's `push` fires in the fork; a
  `pull_request` fires in the base repo), this repo's own run history, and the
  rainix reusables' source at `main` for the no-secrets path. All independent of
  the file being changed — the workflow was never consulted to decide what the
  workflow should do.
- **Category check:** #90 asks for (A) fork PRs get checks, (B) `flake.lock`'s
  rainix pin converged with CI's `RAINIX_SHA`, (C) an assertion enforcing (B) in
  rainix's `rainix-sol-static.yaml`. **Covered A.** B and C are deliberately not
  covered — see below: (C) is a rainix file by construction, and (B) as the
  issue words it lands 57 commits past what CI runs, so it would fail (C) the
  day it landed.

## Not done here: the `flake.lock` half of #90, and why

#90 also asks for `nix flake update rainix` in this repo plus a lock-vs-CI
assertion in `rainix-sol-static.yaml`. The assertion is a rainix change by
construction. The local half does not work as written:

| | rev | date |
|---|---|---|
| `flake.lock` `nodes.rainix.locked.rev` | `f22d4dca` | 2026-06-01 |
| `RAINIX_SHA` in rainix's three `rainix-sol-*.yaml` at `main` | `53e96a7d` | 2026-07-10 |
| rainix `main` | `7f223b4a` | 2026-08-16 |

`f22d4dca...53e96a7d` is 93 commits (the issue's figure, re-measured and
confirmed). But `53e96a7d...7f223b4a` is a further **57** commits, so running
the update lands the lock on `7f223b4a`, not on what CI runs — measured, not
inferred, on a throwaway clone:

```
• Updated input 'rainix':
    'github:rainlanguage/rainix/f22d4dcaca61717e33eac65e7b09b9a82f604c1f' (2026-06-01)
  → 'github:rainlanguage/rainix/7f223b4af5c8ae787dec73e2714ac9afdee960a6' (2026-08-16)
```

That does not converge local with CI, it inverts the drift, and it would fail
the assertion #90 itself proposes on the day it lands. (`nix flake update
rainix` is also not the command on the nix in this shell, 2.18.1 — it errors
`cannot find flake 'flake:rainix' in the flake registries`; `nix flake lock
--update-input rainix` is.)

Pinning the lock to `53e96a7d` by hand is not available either: nix re-locks
whenever `flake.lock`'s `original` disagrees with the input declared in
`flake.nix`, so keeping `rainix.url` deliberately unpinned while holding
`locked.rev` at CI's SHA means hand-forging `rev`/`narHash`/`lastModified` into
the lock, which re-drifts the next time anyone runs `nix flake lock`.

The two sources of truth are the real defect and both live in rainix — either
`RAINIX_SHA` tracks rainix `main` so a consumer's
`nix flake lock --update-input rainix` converges (and the proposed assertion
becomes satisfiable), or the reusables stop hardcoding a SHA and run
`nix develop -c` against the consumer's own checked-out flake, making
`flake.lock` the single source of truth. Left for a rainix PR rather than
re-implemented here.

## Adjacent, not touched

`on: [push]` with no `pull_request` is org-wide, not a rain.solmem quirk —
`rain.interpreter`, `rain.math.float`, `rain.factory` and `rain.metadata` all
carry the identical five-line `rainix-sol.yaml` with `on: [push]`. Same fork
blindness in each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
