### PR TITLE
Scope unsafeExtend's extend-is-never-mutated promise to non-overlapping arrays

### DIFF
--- a/src/lib/LibBytes32Array.sol
+++ b/src/lib/LibBytes32Array.sol
@@ -314,8 +314,15 @@ library LibBytes32Array {
     /// caller between the allocating and non-allocating logic due to subtle
     /// optimisation reasons. To use this function safely THE CALLER MUST NOT USE
     /// THE BASE ARRAY AND MUST USE THE RETURNED ARRAY ONLY. It is safe to use
-    /// the extend array after calling this function as it is never mutated, it
-    /// is only copied from.
+    /// the extend array after calling this function PROVIDED IT DOES NOT OVERLAP
+    /// THE BASE ARRAY, as a non overlapping extend array is only copied from and
+    /// never written to. Overlap is neither checked nor rejected. An extend
+    /// array that overlaps base is part of the base array, so it carries the
+    /// base array's obligation and must not be used after the call either.
+    /// Passing one array as both base and extend is total overlap: the two
+    /// share a single length word, so writing the combined length through base
+    /// writes it through extend as well, and the extend array's length reads
+    /// back as the combined length.
     ///
     /// @param b The base integer array that will be extended by `e`.
     /// @param e The extend integer array that extends `b`.

--- a/src/lib/LibUint256Array.sol
+++ b/src/lib/LibUint256Array.sol
@@ -314,8 +314,15 @@ library LibUint256Array {
     /// caller between the allocating and non-allocating logic due to subtle
     /// optimisation reasons. To use this function safely THE CALLER MUST NOT USE
     /// THE BASE ARRAY AND MUST USE THE RETURNED ARRAY ONLY. It is safe to use
-    /// the extend array after calling this function as it is never mutated, it
-    /// is only copied from.
+    /// the extend array after calling this function PROVIDED IT DOES NOT OVERLAP
+    /// THE BASE ARRAY, as a non overlapping extend array is only copied from and
+    /// never written to. Overlap is neither checked nor rejected. An extend
+    /// array that overlaps base is part of the base array, so it carries the
+    /// base array's obligation and must not be used after the call either.
+    /// Passing one array as both base and extend is total overlap: the two
+    /// share a single length word, so writing the combined length through base
+    /// writes it through extend as well, and the extend array's length reads
+    /// back as the combined length.
     ///
     /// @param b The base integer array that will be extended by `e`.
     /// @param e The extend integer array that extends `b`.

--- a/test/src/lib/LibArray.selfExtend.t.sol
+++ b/test/src/lib/LibArray.selfExtend.t.sol
@@ -66,6 +66,25 @@ contract LibArraySelfExtendTest is Test {
         assertEq(extended[5], 0x33);
     }
 
+    /// The extend array is only left alone if it does not overlap base.
+    /// Passing one array as both is total overlap: base's length word IS
+    /// extend's length word, so rewriting it to the combined length is visible
+    /// through the alias, which is what the NatSpec's precondition is about.
+    function testSelfExtendUint256MutatesTheSharedLengthWord() external pure {
+        uint256[] memory a = new uint256[](3);
+
+        a.unsafeExtend(a);
+
+        uint256 lengthAfter;
+        // Deliberately NOT ("memory-safe"): the length word is rewritten by
+        // assembly the compiler cannot see through, so a read it is free to
+        // fold back to the allocated constant would pass either way.
+        assembly {
+            lengthAfter := mload(a)
+        }
+        assertEq(lengthAfter, 6, "aliased length word not rewritten");
+    }
+
     function testSelfExtendBytes32WritesNothingAboveFreeMemoryPointer() external pure {
         bytes32[] memory a = new bytes32[](3);
         a[0] = bytes32(uint256(0x11));
@@ -102,5 +121,20 @@ contract LibArraySelfExtendTest is Test {
         assertEq(extended[1], bytes32(uint256(0xBB)));
         assertEq(extended[2], bytes32(uint256(0xAA)));
         assertEq(extended[3], bytes32(uint256(0xBB)));
+    }
+
+    /// As above for `bytes32[]`: total overlap shares the length word, so the
+    /// combined length is visible through the alias.
+    function testSelfExtendBytes32MutatesTheSharedLengthWord() external pure {
+        bytes32[] memory a = new bytes32[](2);
+
+        a.unsafeExtend(a);
+
+        uint256 lengthAfter;
+        // Deliberately NOT ("memory-safe") — see above.
+        assembly {
+            lengthAfter := mload(a)
+        }
+        assertEq(lengthAfter, 4, "aliased length word not rewritten");
     }
 }


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.solmem/issues/61

The issue asks for a ruling between **(a)** scoping the NatSpec promise and
**(b)** rejecting `base == extend` at runtime. This takes **(a)**, and widens
it: the precondition is *non overlap*, not *non equality*.

## The promise, before

> It is safe to use the extend array after calling this function as it is never
> mutated, it is only copied from.

Unconditional, and false whenever extend overlaps base.

## Equality is not the boundary — measured

`base == extend` is the case the issue names: the two share one length word, so
`mstore(base, totalLength)` is visible as `extend.length`. But it is only the
total-overlap end of a range. A *partial* overlap writes extend's **data**.

Probe (run locally, not committed — `test/src/lib/ZZScratchOverlapProbe.t.sol`):
`base = new uint256[](4)`, `base[1] = 3`, `extend := add(base, 0x40)` — so
extend's header is base's word 1, `extend.length == 3`, and extend's third data
word sits one past base's end, planted with `0xE0`. `extend != base`, and
extend's own length word is never written. After
`base.unsafeExtend(extend)`:

```
[FAIL: extend data untouched by overlap: 192 != 224] testPartialOverlapWritesExtendData()
```

`0xE0` (224) became `0xC0` (192): the copy destination `baseEnd` overlaps the
tail of extend's own region, so extend is written to, not merely copied from.
Overlapping arrays are constructible with this library's own
`unsafeAsUint256Array(Pointer)`, so this is reachable, not hypothetical.

Consequence for the ruling: **(b) as specified would not make the NatSpec
unconditionally true.** `require(base != extend)` closes the total-overlap case
and leaves the partial-overlap case, i.e. the promise stays false and now costs
gas. Making it actually unconditional needs a region-overlap comparison on every
call — on a function `unsafe*`-prefixed precisely because the caller carries the
obligations, in a library inherited by ~23 repos where any new revert is a
consumer-visible behaviour change.

There is a third option, **(c)**: route the aliased case through the allocating
path. It does leave extend unmutated and it does return the correct doubled
array. It was rejected because it costs an equality check plus a full copy of
base on the hot path, it changes audited runtime behaviour, and it does not
resolve the underlying contradiction: when the same array is both base and
extend, "THE CALLER MUST NOT USE THE BASE ARRAY" and "it is safe to use the
extend array" are instructions about one array, and no implementation can make
both true. (c) is used below as the mutant that proves the new tests
discriminate — and note it also fails two *existing* tests.

## The change

Comments in `src/lib/LibUint256Array.sol` and `src/lib/LibBytes32Array.sol`
state the precondition and what happens without it, plus one test per array
library pinning the total-overlap consequence. No runtime change: the only
`src` edits are comment lines, so there is zero drift on the Protofire-audited
source at `228b35c6`.

## Red, then green

Mutant = option (c), `switch eq(outputCursor, baseEnd)` →
`switch and(eq(outputCursor, baseEnd), iszero(eq(base, extend)))` in both
libraries:

```
Ran 6 tests for test/src/lib/LibArray.selfExtend.t.sol:LibArraySelfExtendTest
[PASS] testSelfExtendBytes32DoublesTheContents() (gas: 1489)
[FAIL: aliased length word not rewritten: 2 != 4] testSelfExtendBytes32MutatesTheSharedLengthWord()
[FAIL: wrote at or above the free memory pointer: 51 != 3735879681] testSelfExtendBytes32WritesNothingAboveFreeMemoryPointer()
[PASS] testSelfExtendUint256DoublesTheContents() (gas: 1757)
[FAIL: aliased length word not rewritten: 3 != 6] testSelfExtendUint256MutatesTheSharedLengthWord()
[FAIL: wrote at or above the free memory pointer: 51 != 3735879681] testSelfExtendUint256WritesNothingAboveFreeMemoryPointer()
Suite result: FAILED. 2 passed; 4 failed; 0 skipped
```

Both new tests die on the mutant. The mutation was reverted with
`git checkout -- src` before the green run.

Suite: 350 tests before, 352 after, 0 failed.

## QA
- Discriminating tests: `testSelfExtendUint256MutatesTheSharedLengthWord`,
  `testSelfExtendBytes32MutatesTheSharedLengthWord` — each fails on the option
  (c) mutant (`3 != 6`, `2 != 4`, transcribed above). They do NOT fail on
  unmutated `main`: the `src` diff is comment-only, so there is no behaviour
  change for a test to fail without. What they pin is the behaviour the new
  NatSpec sentence describes, so the prose cannot silently stop being true.
  Both read the length word through non-`("memory-safe")` assembly so the
  optimizer cannot fold the read back to the allocated constant.
- Mutations applied: `src/lib/LibUint256Array.sol` and
  `src/lib/LibBytes32Array.sol`, `switch eq(outputCursor, baseEnd)` →
  `switch and(eq(outputCursor, baseEnd), iszero(eq(base, extend)))` (option
  (c), the only alternative that would make the old promise true) → killed by
  both new tests, and also by the two pre-existing
  `...WritesNothingAboveFreeMemoryPointer` tests. Reverted with
  `git checkout -- src` before the green run; suite green at 352 after.
- Oracle: the EVM memory model, not the implementation. Expected values are
  derived from the layout — a 3 word array self-extended must read length 6
  because base's length word and extend's length word are one word — and the
  overlap claim was measured with the uncommitted probe above, which asserts
  the *promise* (`extend data untouched`) and watches it break.
- Category check: the issue asks for a ruling between (a) scope the promise and
  (b) reject aliasing. Covered: (a), widened from the issue's `extend does not
  alias base` to the property `extend does not overlap base`, with the
  measurement that rules out (b) as specified. Closes rather than Refs because
  the false NatSpec sentence — the whole subject of the issue — is gone.

## If the ruling is (b)

Then this PR is the wrong shape and should come back as needs-work: (b) is a
runtime guard plus a revert test plus an audited-source drift note, and the
NatSpec would say the aliased case reverts rather than that the caller must
avoid it. The measurement above is the argument against (b) as written, not a
substitute for the ruling.
