### PR TITLE
docs: a changelog that ships in the package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,127 @@
+# Changelog
+
+What changed in every published `rain-solmem` revision, so a consumer can tell a
+memory corruption fix from a comment edit without diffing two package zips.
+
+This file ships inside the Soldeer package, so it is readable at
+`dependencies/rain-solmem-<version>/CHANGELOG.md`.
+
+Each heading is a Soldeer revision. The top heading is the version in
+`[package].version` of `foundry.toml`: the next, unpublished revision, which is
+what the package is published under the next time its content changes. Dates are
+the revision's registry timestamp, UTC, and are filled in once it is published.
+
+Every pull request that changes `src/**` adds an entry under the top heading.
+
+Revisions below `0.1.2` predate the Soldeer registry's record of this package.
+
+## 0.1.11
+
+### Added
+
+- This changelog.
+
+## 0.1.10 — 2026-08-17
+
+### Fixed
+
+- `LibStackPointer.unsafeList` scaled `length` to a byte offset in unchecked
+  assembly. A `length` above `type(uint256).max / 0x20` wrapped that offset
+  while the length word written into the header did not, so the header landed as
+  if a small array had been requested and then claimed the full `length`.
+  Solidity's own bounds check trusts that length word, so the result was a read
+  and write primitive over the whole heap, reachable from callers containing no
+  assembly. The scaling is now checked and reverts with an arithmetic overflow
+  panic.
+- `LibStackSentinel.consumeSentinelTuples` scaled the tuple size `n` to a byte
+  stride in unchecked assembly, so an oversized `n` wrapped to a small stride
+  and the scan served the request as if a much smaller `n` had been asked for.
+  The scaling is now checked and reverts with an arithmetic overflow panic.
+- `LibUint256Matrix.itemCount` and `LibBytes32Matrix.itemCount` summed sub array
+  lengths unchecked, so a wrapping total returned a count smaller than one of
+  the sub arrays it was totalling. The running total now reverts with
+  `Panic(uint256)` code `0x11` on wrap, byte for byte what checked Solidity
+  arithmetic produces.
+- `LibUint256Matrix.flatten` and `LibBytes32Matrix.flatten` scaled the item
+  count to an allocation size unchecked. A wrapping scale sized the allocation
+  from one number while stamping the length word from another, handing back an
+  array whose declared length far exceeded the memory reserved for it. The
+  scaling is now checked and reverts with an arithmetic overflow panic.
+
+### Documentation
+
+- `LibStackSentinel.consumeSentinelTuples` documents that the failure modes for
+  a tuple stride the stack cannot hold are not uniform, and that an out of range
+  `n` is not guaranteed to fail loudly.
+- `LibUint256Matrix.flatten` and `LibBytes32Matrix.flatten` state the premise
+  their copy loop's no-wrap argument rests on: the loop only writes above the
+  free memory pointer as it stood on entry, so the sub array length words it
+  re-reads are the ones `itemCount` summed.
+
+## 0.1.9 — 2026-08-05
+
+### Changed
+
+- `LibStackSentinel.consumeSentinelTuples` reverts with the new error
+  `UnallocatedStack(Pointer upper, Pointer allocated)` when the stack extends
+  above the allocated memory pointer. The tuples array is allocated at that
+  pointer and grows upward, so such a stack was overwritten by the very array
+  that referenced it. Inputs that previously returned now revert.
+
+## 0.1.8 — 2026-08-05
+
+### Changed
+
+- `LibStackSentinel.consumeSentinelTuples` checks its stack bounds before
+  scanning. An `upper` below `lower` reverts with `InvalidStackBounds` up front
+  rather than only on the missing sentinel path, and an `upper` that is not a
+  whole number of words above `lower` reverts with `UnalignedStackPointer`.
+  Unaligned bounds previously scanned across the boundary of two of the caller's
+  stack items. Inputs that previously returned now revert.
+
+### Documentation
+
+- The `MissingSentinel` doc no longer lists `upper` below `lower` as one of its
+  triggers, which is now its own error.
+
+## 0.1.7 — 2026-07-25
+
+No library source changes. Packaging metadata only.
+
+## 0.1.6 — 2026-07-25
+
+### Documentation
+
+- `LibMemCpy.unsafeCopyWordsTo` documents that its byte count `length * 32` is
+  computed in unchecked assembly, that the resulting wrap is periodic at every
+  multiple of `2**251` rather than a tail above one threshold, and that an
+  affordable residue larger than the caller's allocation over-copies past it and
+  returns successfully. No behaviour change.
+
+## 0.1.5 — 2026-07-25
+
+### Documentation
+
+- `LibStackPointer.toIndexSigned` documents that its two pointers must be word
+  aligned with each other, not aligned in absolute terms, and that `upper` may
+  be below `lower` for a negative index. No behaviour change.
+
+## 0.1.4 — 2026-07-25
+
+### Fixed
+
+- `LibUint256Array.unsafeExtend` and `LibBytes32Array.unsafeExtend` read
+  `extend`'s length word after overwriting `base`'s. When `extend` aliases
+  `base` those are the same word, so the copy ran on the already combined length
+  and wrote past the free memory pointer. The length is now read once, before
+  the write.
+
+## 0.1.3 — 2026-05-09
+
+No library source changes. CI configuration only, none of which is part of the
+package, so this revision's contents are identical to `0.1.2`'s.
+
+## 0.1.2 — 2026-05-09
+
+No library source changes. A README rewrite and a publish workflow change, of
+which only the README is part of the package.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -8,6 +8,7 @@ path = [
   "audit/**/",
   ".audit/**",
   ".gitignore",
+  "CHANGELOG.md",
   "README.md",
   "flake.lock",
   "flake.nix",


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.solmem/issues/87

## What this lands

A root `CHANGELOG.md` that ships inside the Soldeer package, so a consumer can
tell `0.1.4` (an out-of-bounds write fix in `unsafeExtend`) from `0.1.6` (a
NatSpec paragraph) without downloading and diffing two zips.

It is backfilled for every revision the Soldeer registry has a record of —
`0.1.2` through `0.1.10` — from the git tag each was published at, and carries a
`0.1.11` section for the version currently in development.

`REUSE.toml` gains `CHANGELOG.md` so `reuse lint` stays compliant.

## Two deviations from the issue's proposed fix, with reasons

**1. Version-numbered headings, not `## Unreleased`.**

`CHANGELOG.md` is not in `.soldeerignore`, so it is part of the published
package — that is the whole point of adding it. Under the next-version release
lifecycle, `[package].version` is the *next, unpublished* version and
`rainix-autopublish` publishes the tree under exactly that number. An
`## Unreleased` heading would therefore ship as the top section of the zip a
consumer just installed, describing the version they are holding as unreleased.

So the top heading is the version from `foundry.toml` — `0.1.11` today. It is
already the correct, known number, and it needs no rename at release time.

**2. The `notes-file:` plumbing and the CI gate are not in this PR, because
they are not in this repo.**

Evidence, against `rainlanguage/rainix@7f223b4`:

- `.github/actions/gh-release/action.yml` accepts `tag-name`, `name`, `files`,
  `github-token`. There is no `notes-file` / `body` input, so the composite
  cannot pass notes to the `softprops/action-gh-release` it wraps. Adding it is
  a change to that composite plus the soldeer release step in
  `.github/workflows/rainix-autopublish.yaml`.
- That same workflow's only pre-publish test step is `Cargo test`, gated on
  `inputs.crates != '' || inputs.crate != ''`. `rain.solmem` calls it with
  `soldeer-package` only, so **no test runs before `forge soldeer push`**.
  Gating the soldeer publish is one step in the reusable, and it fixes every
  soldeer consumer at once.

Both belong upstream — rainix owns shared CI. They are written up in the report
on this issue rather than reimplemented here.

## Evidence

**`reuse lint` — red without the `REUSE.toml` entry:**

```
* Files with copyright information: 70 / 71
* Files with license information: 70 / 71

Unfortunately, your project is not compliant with version 3.3 of the REUSE Specification :-(
reuse exit=1
```

**Green with it:**

```
* Files with copyright information: 71 / 71
* Files with license information: 71 / 71

Congratulations! Your project is compliant with version 3.3 of the REUSE Specification :-)
reuse exit=0
```

**`CHANGELOG.md` is in the published package** —
`forge soldeer push rain-solmem~0.1.11 --dry-run`, contents of the zip:

```
     3166  README.md
      453  REUSE.toml
    17901  LICENSE
      ...  src/error/*.sol, src/lib/*.sol, LICENSES/
     5370  CHANGELOG.md
---------  -------
   133333  20 files
```

**Suite unchanged** (docs + packaging metadata only): 34 suites, 350 tests
passed, 0 failed, 0 skipped, before and after.

`forge fmt --check` exit 0. `slither .` clean.

## Note for the other issue agents working this repo

`0.1.11`'s section currently lists only this changelog. The other in-flight PRs
predate this file, so any `src/**` change that lands in `0.1.11` needs its entry
added — in its own PR or as a backfill before `0.1.11` publishes.

## QA

- Discriminating tests: n/a as a Solidity test — the diff adds no Solidity and
  changes no bytecode. The discriminating check for this change is `reuse lint`,
  which is a CI job (`rainix-sol-legal`): it exits 1 with `70 / 71` files
  covered on this branch with the `REUSE.toml` line reverted, and exits 0 with
  `71 / 71` with it. Transcribed above. The second claim the diff makes — that
  `CHANGELOG.md` reaches consumers — is discriminated by
  `forge soldeer push rain-solmem~0.1.11 --dry-run`, whose zip listing is
  transcribed above; a `.soldeerignore`d file would be absent from it.
- Mutations applied: n/a — docs and packaging metadata only, no executable
  lines to mutate. The nearest equivalent, reverting the one functional line in
  the diff (`"CHANGELOG.md"` in `REUSE.toml`), was applied and is the red
  transcribed above.
- Oracle: the git tags `sol-v0.1.4` … `sol-v0.1.10` and `v0.1.2` / `v0.1.3`,
  and the Soldeer registry's revision list
  (`api.soldeer.xyz/api/v1/revision?project_name=rain-solmem`) for the dates.
  Every entry is derived from the diff between one release tag and the next,
  not from the issue's narrative. Doing that surfaced one correction: the issue
  attributes the `unsafeExtend` out-of-bounds write fix (#57) to `0.1.5`. #57
  merged at `a7fd1e1`, whose child `315e7dd` is tagged `sol-v0.1.4`, so it
  shipped in **`0.1.4`**. `0.1.5` was the `toIndexSigned` alignment NatSpec.
  The issue's point is unaffected — one of those three 40-minute revisions was
  a memory-safety fix and the neighbouring ones were prose.
- Category check: the issue asks for (1) a changelog that ships, in
  `REUSE.toml`, surfaced in the release; (2) an expressible bump level; (3) the
  publish gated on CI. Covered here: (1)'s repo half — the file, and its
  `REUSE.toml` entry. Not here, with evidence in the section above: (1)'s
  release-notes half and (3) are both changes to `rainlanguage/rainix@7f223b4`
  (`.github/actions/gh-release/action.yml` has no notes input;
  `rainix-autopublish.yaml`'s only pre-publish test step is skipped for
  soldeer-only callers). For (2), reading the current gate
  (`rainix-static/src/soldeer_gate.rs`) shows the issue's premise has since
  become too strong: the published version is `[package].version` verbatim and
  the only constraint is that it be ahead of the registry, so a hand-written
  minor or major bump in a PR already publishes as written. What remains is
  that the *automatic* post-publish bump is patch-only and nothing enforces a
  level — reported for a decision rather than guessed at here.
