### PR TITLE
Matrix endPointer is the end of the pointer array, not an allocation boundary

### DIFF
--- a/src/lib/LibBytes.sol
+++ b/src/lib/LibBytes.sol
@@ -43,19 +43,27 @@ library LibBytes {
     /// start of a multiple of 32, UNLIKE the free memory pointer at 0x40.
     ///
     /// @param data Bytes to get the pointer to the end of.
-    /// @return pointer Pointer to the end of the bytes data structure.
+    /// @return pointer Pointer to the first byte after the `length` bytes of
+    /// data, i.e. NOT including the word alignment padding. Use
+    /// `endAllocatedPointer` for the end of the word aligned region.
     function endDataPointer(bytes memory data) internal pure returns (Pointer pointer) {
         assembly ("memory-safe") {
             pointer := add(data, add(0x20, mload(data)))
         }
     }
 
-    /// Pointer to the end of the memory allocated for bytes.
+    /// Pointer to the end of the word aligned region implied by the CURRENT
+    /// length of some bytes.
     ///
     /// The allocator is ALWAYS aligned to whole words, i.e. 32 byte multiples,
     /// for data structures allocated by Solidity. This includes `bytes` which
     /// means that any time the length of some `bytes` is NOT a multiple of 32
-    /// the alloation will point past the end of the `bytes` data.
+    /// the allocation will point past the end of the `bytes` data.
+    ///
+    /// This is the end of the memory Solidity allocated only while the length
+    /// word is the one Solidity wrote. `truncate` mutates the length word and
+    /// leaks the tail, so after a truncation this pointer is BELOW the end of
+    /// the real allocation by the size of the leaked region.
     ///
     /// There is no guarantee that the memory region between `endDataPointer`
     /// and `endAllocatedPointer` is zeroed out. It is best to think of that
@@ -63,8 +71,9 @@ library LibBytes {
     ///
     /// Almost always, e.g. for the purpose of copying data between regions, you
     /// will want `endDataPointer` rather than this function.
-    /// @param data Bytes to get the end of the allocated data region for.
-    /// @return pointer Pointer to the end of the allocated data region.
+    /// @param data Bytes to get the end of the word aligned region for.
+    /// @return pointer Pointer to the end of the word aligned region implied by
+    /// the current length.
     function endAllocatedPointer(bytes memory data) internal pure returns (Pointer pointer) {
         assembly ("memory-safe") {
             pointer := add(data, and(add(add(mload(data), 0x20), 0x1f), not(0x1f)))

--- a/src/lib/LibBytes32Array.sol
+++ b/src/lib/LibBytes32Array.sol
@@ -29,9 +29,15 @@ library LibBytes32Array {
         }
     }
 
-    /// Pointer to the end of the allocated memory of an array.
+    /// Pointer to the end of the data of an array, i.e. one word past its last
+    /// item.
+    ///
+    /// This is derived from the CURRENT length word, so it is the end of the
+    /// allocated region only for an array that has not been shrunk. `truncate`
+    /// mutates the length word and leaks the tail, so after a truncation the
+    /// allocation extends beyond this pointer.
     /// @param array The array to get the end pointer of.
-    /// @return pointer The pointer to the end of `array`.
+    /// @return pointer The pointer to the end of the data of `array`.
     function endPointer(bytes32[] memory array) internal pure returns (Pointer pointer) {
         assembly ("memory-safe") {
             pointer := add(array, add(0x20, mul(0x20, mload(array))))

--- a/src/lib/LibBytes32Matrix.sol
+++ b/src/lib/LibBytes32Matrix.sol
@@ -27,11 +27,22 @@ library LibBytes32Matrix {
         }
     }
 
-    /// Pointer to the end of the allocated memory of a matrix.
-    /// Note that the data of a `bytes32[][]` is _references_ to the `bytes32[]`
-    /// start pointers and does NOT include the arrays themselves.
+    /// Pointer to one word past the last `bytes32[]` REFERENCE in a matrix,
+    /// i.e. the end of the matrix's pointer array.
+    ///
+    /// This is NOT the end of the memory allocated for the matrix. The data of a
+    /// `bytes32[][]` is _references_ to the `bytes32[]` start pointers and does
+    /// NOT include the arrays themselves. Those arrays are separate allocations
+    /// lying outside the pointer array entirely: above it for a matrix built by
+    /// `new bytes32[][](n)`, below it for a matrix built by `matrixFrom` from
+    /// existing arrays. A matrix is therefore not one contiguous allocation and
+    /// no pointer marks the end of it.
+    ///
+    /// Allocating or writing at this pointer overwrites whatever sits above the
+    /// pointer array. For a matrix built by `new bytes32[][](n)` that is the
+    /// inner arrays themselves, so it corrupts the matrix.
     /// @param matrix The matrix to get the end pointer of.
-    /// @return pointer The pointer to the end of `matrix`.
+    /// @return pointer The pointer one word past the last reference in `matrix`.
     function endPointer(bytes32[][] memory matrix) internal pure returns (Pointer pointer) {
         assembly ("memory-safe") {
             pointer := add(matrix, add(0x20, mul(0x20, mload(matrix))))

--- a/src/lib/LibUint256Array.sol
+++ b/src/lib/LibUint256Array.sol
@@ -29,9 +29,15 @@ library LibUint256Array {
         }
     }
 
-    /// Pointer to the end of the allocated memory of an array.
+    /// Pointer to the end of the data of an array, i.e. one word past its last
+    /// item.
+    ///
+    /// This is derived from the CURRENT length word, so it is the end of the
+    /// allocated region only for an array that has not been shrunk. `truncate`
+    /// mutates the length word and leaks the tail, so after a truncation the
+    /// allocation extends beyond this pointer.
     /// @param array The array to get the end pointer of.
-    /// @return pointer The pointer to the end of `array`.
+    /// @return pointer The pointer to the end of the data of `array`.
     function endPointer(uint256[] memory array) internal pure returns (Pointer pointer) {
         assembly ("memory-safe") {
             pointer := add(array, add(0x20, mul(0x20, mload(array))))

--- a/src/lib/LibUint256Matrix.sol
+++ b/src/lib/LibUint256Matrix.sol
@@ -27,11 +27,22 @@ library LibUint256Matrix {
         }
     }
 
-    /// Pointer to the end of the allocated memory of a matrix.
-    /// Note that the data of a `uint256[][]` is _references_ to the `uint256[]`
-    /// start pointers and does NOT include the arrays themselves.
+    /// Pointer to one word past the last `uint256[]` REFERENCE in a matrix,
+    /// i.e. the end of the matrix's pointer array.
+    ///
+    /// This is NOT the end of the memory allocated for the matrix. The data of a
+    /// `uint256[][]` is _references_ to the `uint256[]` start pointers and does
+    /// NOT include the arrays themselves. Those arrays are separate allocations
+    /// lying outside the pointer array entirely: above it for a matrix built by
+    /// `new uint256[][](n)`, below it for a matrix built by `matrixFrom` from
+    /// existing arrays. A matrix is therefore not one contiguous allocation and
+    /// no pointer marks the end of it.
+    ///
+    /// Allocating or writing at this pointer overwrites whatever sits above the
+    /// pointer array. For a matrix built by `new uint256[][](n)` that is the
+    /// inner arrays themselves, so it corrupts the matrix.
     /// @param matrix The matrix to get the end pointer of.
-    /// @return pointer The pointer to the end of `matrix`.
+    /// @return pointer The pointer one word past the last reference in `matrix`.
     function endPointer(uint256[][] memory matrix) internal pure returns (Pointer pointer) {
         assembly ("memory-safe") {
             pointer := add(matrix, add(0x20, mul(0x20, mload(matrix))))

--- a/test/src/lib/LibBytes.t.sol
+++ b/test/src/lib/LibBytes.t.sol
@@ -47,6 +47,11 @@ contract LibBytesTest is Test {
     /// a `bytes` in memory rather than from the implementation: a 32 byte length
     /// prefix, then `length` bytes of data, then padding out to a whole number
     /// of 32 byte words.
+    ///
+    /// Every value here derives from the CURRENT length word, so the last of
+    /// them is the end of the real allocation only for `data` that has not been
+    /// truncated. `testEndAllocatedPointerDivergesAfterTruncate` pins the case
+    /// where it is not.
     function checkPointers(bytes memory data, uint256 length) internal pure {
         uint256 start = Pointer.unwrap(data.startPointer());
 
@@ -95,6 +100,27 @@ contract LibBytesTest is Test {
             assertEq(uint8(data[i]), uint8((i % 251) + 1));
         }
         checkPointers(data, 300);
+    }
+
+    /// `endAllocatedPointer` is derived from the CURRENT length word, so it is
+    /// the end of the memory Solidity reserved only while that word is the one
+    /// Solidity wrote. `truncate` mutates it and leaks the tail, which leaves
+    /// the reported pointer below the end of the real allocation.
+    function testEndAllocatedPointerDivergesAfterTruncate() public pure {
+        bytes memory data = new bytes(1000);
+        // Read the free memory pointer before any assertion, as assertions
+        // allocate. Nothing has been allocated since `data`, so this is the end
+        // of its allocation: 1000 bytes padded up to 1024.
+        uint256 allocationEnd = uint256(Pointer.unwrap(LibPointer.allocatedMemoryPointer()));
+        uint256 endBefore = uint256(Pointer.unwrap(data.endAllocatedPointer()));
+
+        data.truncate(300);
+        uint256 endAfter = uint256(Pointer.unwrap(data.endAllocatedPointer()));
+
+        assertEq(endBefore, allocationEnd, "untruncated: end of the allocation");
+        // 300 bytes pad up to 320, leaving 704 bytes of the 1024 leaked above
+        // the reported pointer and still inside the allocation.
+        assertEq(allocationEnd - endAfter, 704, "truncated: leaked tail above endAllocatedPointer");
     }
 
     /// Truncating to exactly the current length is a no-op, NOT a revert.

--- a/test/src/lib/LibBytes32Array.truncate.t.sol
+++ b/test/src/lib/LibBytes32Array.truncate.t.sol
@@ -77,6 +77,25 @@ contract LibBytes32ArrayTruncateTest is Test {
         assertEq(a, b);
     }
 
+    /// `endPointer` is derived from the CURRENT length word, so it marks the end
+    /// of the allocation only for an array that has not been shrunk. `truncate`
+    /// leaks the tail, which leaves `endPointer` below the end of the memory
+    /// still reserved for the array.
+    function testEndPointerDivergesAfterTruncate() public pure {
+        bytes32[] memory a = new bytes32[](10);
+        // Read the free memory pointer before any assertion, as assertions
+        // allocate. Nothing has been allocated since `a`, so this is the end of
+        // its allocation.
+        uint256 allocationEnd = uint256(Pointer.unwrap(LibPointer.allocatedMemoryPointer()));
+        uint256 endBefore = uint256(Pointer.unwrap(LibBytes32Array.endPointer(a)));
+
+        LibBytes32Array.truncate(a, 4);
+        uint256 endAfter = uint256(Pointer.unwrap(LibBytes32Array.endPointer(a)));
+
+        assertEq(endBefore, allocationEnd, "untruncated: endPointer is the end of the allocation");
+        assertEq(allocationEnd - endAfter, 6 * 0x20, "truncated: six words still allocated above endPointer");
+    }
+
     function testTruncateGas0() public pure {
         LibBytes32Array.truncate(
             LibBytes32Array.arrayFrom(bytes32(uint256(1)), bytes32(uint256(2)), bytes32(uint256(3))), 1

--- a/test/src/lib/LibBytes32Matrix.endPointer.t.sol
+++ b/test/src/lib/LibBytes32Matrix.endPointer.t.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+
+import {LibBytes32Array} from "src/lib/LibBytes32Array.sol";
+import {LibBytes32Matrix, LibPointer, Pointer} from "src/lib/LibBytes32Matrix.sol";
+
+/// `endPointer` on a matrix is one word past the last REFERENCE, which is not
+/// the end of any allocation. The NatSpec on `endPointer` states where the inner
+/// arrays sit relative to that pointer and that writing there corrupts them.
+/// These tests pin those claims against the real memory layout so the warning
+/// cannot quietly become false.
+contract LibBytes32MatrixEndPointerTest is Test {
+    using LibBytes32Array for bytes32[];
+    using LibBytes32Matrix for bytes32[][];
+
+    /// A matrix built with `new` allocates the pointer array first, so the inner
+    /// arrays are ABOVE it and `endPointer` lands on the first of them rather
+    /// than on free memory.
+    function testEndPointerIsFirstInnerArrayForNewMatrix() external pure {
+        bytes32[][] memory matrix = new bytes32[][](2);
+        matrix[0] = new bytes32[](2);
+        matrix[1] = new bytes32[](2);
+
+        assertEq(
+            uint256(Pointer.unwrap(matrix.endPointer())),
+            uint256(Pointer.unwrap(matrix[0].startPointer())),
+            "endPointer is the first inner array"
+        );
+    }
+
+    /// The same layout stated as a bound rather than an exact address: the inner
+    /// arrays of a `new` matrix are allocated above the pointer array, so
+    /// `endPointer` is strictly below the free memory pointer by exactly the
+    /// size of those arrays.
+    function testEndPointerIsBelowFreeMemoryForNewMatrix() external pure {
+        bytes32[][] memory matrix = new bytes32[][](2);
+        matrix[0] = new bytes32[](2);
+        matrix[1] = new bytes32[](3);
+        // Read the free memory pointer before any assertion, as assertions
+        // allocate.
+        uint256 allocationEnd = uint256(Pointer.unwrap(LibPointer.allocatedMemoryPointer()));
+        uint256 end = uint256(Pointer.unwrap(matrix.endPointer()));
+
+        // Two inner arrays, one length word plus two items and one length word
+        // plus three items.
+        assertEq(allocationEnd - end, 0x20 * 7, "inner arrays live above endPointer");
+    }
+
+    /// The consequence the NatSpec warns about, performed. A single word written
+    /// at `endPointer` of a `new` matrix overwrites the length word of the first
+    /// inner array.
+    function testWriteAtEndPointerCorruptsInnerArrayForNewMatrix() external pure {
+        bytes32[][] memory matrix = new bytes32[][](2);
+        matrix[0] = LibBytes32Array.arrayFrom(bytes32(uint256(0x11)), bytes32(uint256(0x22)));
+        matrix[1] = LibBytes32Array.arrayFrom(bytes32(uint256(0x33)), bytes32(uint256(0x44)));
+
+        assertEq(matrix[0].length, 2, "inner length before");
+
+        Pointer end = matrix.endPointer();
+        // Deliberately NOT annotated `memory-safe`. Writing here is precisely
+        // the unsafe act the doc block warns about, and the annotation would be
+        // a lie that lets the optimizer assume the write cannot be observed.
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            mstore(end, 0xdead)
+        }
+
+        assertEq(matrix[0].length, 0xdead, "inner length corrupted");
+    }
+
+    /// A matrix built by `matrixFrom` wraps arrays that were already allocated,
+    /// so its inner arrays are BELOW the pointer array. `endPointer` coincides
+    /// with the free memory pointer here, which is exactly why the doc block
+    /// cannot describe it as the end of the matrix's memory: the same pointer
+    /// means different things for the two ways of building a matrix.
+    function testInnerArraysAreBelowEndPointerForMatrixFrom() external pure {
+        bytes32[] memory a = LibBytes32Array.arrayFrom(bytes32(uint256(0x11)), bytes32(uint256(0x22)));
+        bytes32[] memory b = LibBytes32Array.arrayFrom(bytes32(uint256(0x33)), bytes32(uint256(0x44)));
+        bytes32[][] memory matrix = LibBytes32Matrix.matrixFrom(a, b);
+
+        uint256 allocationEnd = uint256(Pointer.unwrap(LibPointer.allocatedMemoryPointer()));
+        uint256 start = uint256(Pointer.unwrap(matrix.startPointer()));
+        uint256 end = uint256(Pointer.unwrap(matrix.endPointer()));
+
+        assertLt(uint256(Pointer.unwrap(a.startPointer())), start, "a starts below the matrix");
+        assertLt(uint256(Pointer.unwrap(b.startPointer())), start, "b starts below the matrix");
+        assertLe(uint256(Pointer.unwrap(a.endPointer())), start, "a ends at or below the matrix");
+        assertLe(uint256(Pointer.unwrap(b.endPointer())), start, "b ends at or below the matrix");
+        assertEq(end, allocationEnd, "endPointer is the free memory pointer here");
+    }
+}

--- a/test/src/lib/LibUint256Array.truncate.t.sol
+++ b/test/src/lib/LibUint256Array.truncate.t.sol
@@ -73,6 +73,25 @@ contract LibUint256ArrayTruncateTest is Test {
         assertEq(a, b);
     }
 
+    /// `endPointer` is derived from the CURRENT length word, so it marks the end
+    /// of the allocation only for an array that has not been shrunk. `truncate`
+    /// leaks the tail, which leaves `endPointer` below the end of the memory
+    /// still reserved for the array.
+    function testEndPointerDivergesAfterTruncate() public pure {
+        uint256[] memory a = new uint256[](10);
+        // Read the free memory pointer before any assertion, as assertions
+        // allocate. Nothing has been allocated since `a`, so this is the end of
+        // its allocation.
+        uint256 allocationEnd = uint256(Pointer.unwrap(LibPointer.allocatedMemoryPointer()));
+        uint256 endBefore = uint256(Pointer.unwrap(LibUint256Array.endPointer(a)));
+
+        LibUint256Array.truncate(a, 4);
+        uint256 endAfter = uint256(Pointer.unwrap(LibUint256Array.endPointer(a)));
+
+        assertEq(endBefore, allocationEnd, "untruncated: endPointer is the end of the allocation");
+        assertEq(allocationEnd - endAfter, 6 * 0x20, "truncated: six words still allocated above endPointer");
+    }
+
     function testTruncateGas0() public pure {
         LibUint256Array.truncate(LibUint256Array.arrayFrom(1, 2, 3), 1);
     }

--- a/test/src/lib/LibUint256Matrix.endPointer.t.sol
+++ b/test/src/lib/LibUint256Matrix.endPointer.t.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+
+import {LibUint256Array} from "src/lib/LibUint256Array.sol";
+import {LibUint256Matrix, LibPointer, Pointer} from "src/lib/LibUint256Matrix.sol";
+
+/// `endPointer` on a matrix is one word past the last REFERENCE, which is not
+/// the end of any allocation. The NatSpec on `endPointer` states where the inner
+/// arrays sit relative to that pointer and that writing there corrupts them.
+/// These tests pin those claims against the real memory layout so the warning
+/// cannot quietly become false.
+contract LibUint256MatrixEndPointerTest is Test {
+    using LibUint256Array for uint256[];
+    using LibUint256Matrix for uint256[][];
+
+    /// A matrix built with `new` allocates the pointer array first, so the inner
+    /// arrays are ABOVE it and `endPointer` lands on the first of them rather
+    /// than on free memory.
+    function testEndPointerIsFirstInnerArrayForNewMatrix() external pure {
+        uint256[][] memory matrix = new uint256[][](2);
+        matrix[0] = new uint256[](2);
+        matrix[1] = new uint256[](2);
+
+        assertEq(
+            uint256(Pointer.unwrap(matrix.endPointer())),
+            uint256(Pointer.unwrap(matrix[0].startPointer())),
+            "endPointer is the first inner array"
+        );
+    }
+
+    /// The same layout stated as a bound rather than an exact address: the inner
+    /// arrays of a `new` matrix are allocated above the pointer array, so
+    /// `endPointer` is strictly below the free memory pointer by exactly the
+    /// size of those arrays.
+    function testEndPointerIsBelowFreeMemoryForNewMatrix() external pure {
+        uint256[][] memory matrix = new uint256[][](2);
+        matrix[0] = new uint256[](2);
+        matrix[1] = new uint256[](3);
+        // Read the free memory pointer before any assertion, as assertions
+        // allocate.
+        uint256 allocationEnd = uint256(Pointer.unwrap(LibPointer.allocatedMemoryPointer()));
+        uint256 end = uint256(Pointer.unwrap(matrix.endPointer()));
+
+        // Two inner arrays, one length word plus two items and one length word
+        // plus three items.
+        assertEq(allocationEnd - end, 0x20 * 7, "inner arrays live above endPointer");
+    }
+
+    /// The consequence the NatSpec warns about, performed. A single word written
+    /// at `endPointer` of a `new` matrix overwrites the length word of the first
+    /// inner array.
+    function testWriteAtEndPointerCorruptsInnerArrayForNewMatrix() external pure {
+        uint256[][] memory matrix = new uint256[][](2);
+        matrix[0] = LibUint256Array.arrayFrom(0x11, 0x22);
+        matrix[1] = LibUint256Array.arrayFrom(0x33, 0x44);
+
+        assertEq(matrix[0].length, 2, "inner length before");
+
+        Pointer end = matrix.endPointer();
+        // Deliberately NOT annotated `memory-safe`. Writing here is precisely
+        // the unsafe act the doc block warns about, and the annotation would be
+        // a lie that lets the optimizer assume the write cannot be observed.
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            mstore(end, 0xdead)
+        }
+
+        assertEq(matrix[0].length, 0xdead, "inner length corrupted");
+    }
+
+    /// A matrix built by `matrixFrom` wraps arrays that were already allocated,
+    /// so its inner arrays are BELOW the pointer array. `endPointer` coincides
+    /// with the free memory pointer here, which is exactly why the doc block
+    /// cannot describe it as the end of the matrix's memory: the same pointer
+    /// means different things for the two ways of building a matrix.
+    function testInnerArraysAreBelowEndPointerForMatrixFrom() external pure {
+        uint256[] memory a = LibUint256Array.arrayFrom(0x11, 0x22);
+        uint256[] memory b = LibUint256Array.arrayFrom(0x33, 0x44);
+        uint256[][] memory matrix = LibUint256Matrix.matrixFrom(a, b);
+
+        uint256 allocationEnd = uint256(Pointer.unwrap(LibPointer.allocatedMemoryPointer()));
+        uint256 start = uint256(Pointer.unwrap(matrix.startPointer()));
+        uint256 end = uint256(Pointer.unwrap(matrix.endPointer()));
+
+        assertLt(uint256(Pointer.unwrap(a.startPointer())), start, "a starts below the matrix");
+        assertLt(uint256(Pointer.unwrap(b.startPointer())), start, "b starts below the matrix");
+        assertLe(uint256(Pointer.unwrap(a.endPointer())), start, "a ends at or below the matrix");
+        assertLe(uint256(Pointer.unwrap(b.endPointer())), start, "b ends at or below the matrix");
+        assertEq(end, allocationEnd, "endPointer is the free memory pointer here");
+    }
+}


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.solmem/issues/77.

## Which is wrong, the docs or the behaviour

The docs. `endPointer` cannot be changed to match its old wording, because the
wording describes something that does not exist.

`matrixFrom` wraps arrays that were **already allocated**, so their memory is
*below* the pointer array. `new uint256[][](n)` allocates the pointer array
first, so its inner arrays are *above* it. A matrix's memory is therefore not
one contiguous region, and no arithmetic on the matrix pointer can produce "the
end of the allocated memory" for both shapes. Both directions are now pinned by
tests (`testEndPointerIsFirstInnerArrayForNewMatrix`,
`testInnerArraysAreBelowEndPointerForMatrixFrom`).

Changing the value would also break the one thing `endPointer` is actually for:
paired with `dataPointer` it is the loop bound over the references, an invariant
`LibUint256Matrix.pointer.t.sol` already pins and every downstream iteration relies
on.

So the value stays and the doc block now says what the value is, including the
hazard: for a `new` matrix this pointer is the start of the first inner array,
and writing there corrupts it.

## What changed

Doc blocks only — no executable line of `src` moved.

- `LibUint256Matrix.endPointer`, `LibBytes32Matrix.endPointer`: "Pointer to the
  end of the allocated memory of a matrix" replaced with what it returns, where
  the inner arrays sit for each way of building a matrix, and what writing at
  the pointer destroys.
- `LibUint256Array.endPointer`, `LibBytes32Array.endPointer`: the same "end of
  the allocated memory" wording is derived from the CURRENT length word, which
  `truncate` — in the same library — mutates while leaking the tail. Now stated.
- `LibBytes.endAllocatedPointer`: same defect, same fix. Its `@param`/`@return`
  now name the word aligned region implied by the current length rather than the
  allocation. `endDataPointer`'s `@return` claimed the end of "the bytes data
  structure", which is what `endAllocatedPointer` returns; it now names the byte
  after the data and points at `endAllocatedPointer` for the padded region.
  (`alloation` → `allocation` in a line already being rewritten.)

`endAllocatedPointer` keeps its name: renaming it is a breaking API change
across the org and is not this issue.

## Tests

A prose warning nothing checks is how the original copy-paste survived, so the
layout the new wording asserts is now pinned. +11 tests, 350 → 361, suite green.

New `test/src/lib/LibUint256Matrix.endPointer.t.sol` and
`test/src/lib/LibBytes32Matrix.endPointer.t.sol` (4 each):

- `endPointer` of a `new` matrix **is** the start pointer of its first inner
  array;
- the same layout as a bound — `endPointer` is below the free memory pointer by
  exactly the size of the inner arrays;
- a single word written at `endPointer` overwrites the first inner array's
  length word (the write is deliberately **not** annotated `memory-safe`, since
  it is precisely the unsafe act the doc block warns about);
- `matrixFrom` puts its inner arrays entirely below the pointer array, and
  `endPointer` coincides with the free memory pointer there — the same pointer
  meaning two different things is why the doc block cannot call it an allocation
  boundary.

Added to the existing truncate suites: after `truncate`, `endPointer` /
`endAllocatedPointer` sit below the end of the memory still reserved
(`LibUint256Array.truncate.t.sol`, `LibBytes32Array.truncate.t.sol`,
`LibBytes.t.sol`). `LibBytes.t.sol`'s `checkPointers` helper now says its values
derive from the current length word, so the `endAllocatedPointer` assertion it
makes after a truncation is not read as an allocation claim.

## Mutants killed

Each new test was proven non-vacuous by breaking the code it pins.

`endPointer` one word too high (`add(0x20, …)` → `add(0x40, …)`), both matrix
libraries — all 8 new tests fail:

```
[FAIL: endPointer is the first inner array: 256 != 224] testEndPointerIsFirstInnerArrayForNewMatrix()
[FAIL: inner arrays live above endPointer: 192 != 224]  testEndPointerIsBelowFreeMemoryForNewMatrix()
[FAIL: inner length corrupted: 2 != 57005]              testWriteAtEndPointerCorruptsInnerArrayForNewMatrix()
[FAIL: endPointer is the free memory pointer here: 448 != 416] testInnerArraysAreBelowEndPointerForMatrixFrom()
Suite result: FAILED. 0 passed; 4 failed
```

`truncate` made a no-op (`mstore(array, mload(array))`), both array libraries:

```
[FAIL: truncated: six words still allocated above endPointer: 0 != 192] testEndPointerDivergesAfterTruncate()
```

`endAllocatedPointer` with the word alignment rounding dropped:

```
[FAIL: untruncated: end of the allocation: 1160 != 1184] testEndAllocatedPointerDivergesAfterTruncate()
```

## Checks

`forge test` 361 passed / 0 failed (36 suites), `forge fmt --check` exit 0,
`slither .` 0 results, `reuse lint` compliant. Coverage on `src/lib` cannot drop:
no compiled line changed and 11 tests were added.

## Overlap

`#101` touched `itemCount` and `flatten` in both matrix libraries; it did not
touch `endPointer` or its doc block, so nothing this issue depends on moved. The
diff here is confined to the doc blocks `#77` names plus the tests that pin them.


## QA
- Discriminating tests: `testEndPointerIsFirstInnerArrayForNewMatrix`, `testEndPointerIsBelowFreeMemoryForNewMatrix`, `testWriteAtEndPointerCorruptsInnerArrayForNewMatrix`, `testInnerArraysAreBelowEndPointerForMatrixFrom` (x2 — uint256 and bytes32 matrix), `testEndPointerDivergesAfterTruncate` (x2 — uint256 and bytes32 array), `testEndAllocatedPointerDivergesAfterTruncate` — all 11 are new files/cases so none exist on base; each was verified discriminating by mutating the source line it pins and transcribing the failure (below), and each passes on unmutated HEAD.
- Mutations applied:
  - `src/lib/LibUint256Matrix.sol` `endPointer`: `pointer := add(matrix, add(0x20, mul(0x20, mload(matrix))))` → `add(0x40, …)` → killed by all 4 `LibUint256MatrixEndPointerTest` cases (`Suite result: FAILED. 0 passed; 4 failed`), e.g. `[FAIL: endPointer is the first inner array: 256 != 224]` and `[FAIL: inner length corrupted: 2 != 57005]`.
  - `src/lib/LibBytes32Matrix.sol` `endPointer`: same mutation → killed by all 4 `LibBytes32MatrixEndPointerTest` cases (`Suite result: FAILED. 0 passed; 4 failed`).
  - `src/lib/LibUint256Array.sol` `truncate`: `mstore(array, newLength)` → `mstore(array, mload(array))` → killed by `testEndPointerDivergesAfterTruncate` (`[FAIL: truncated: six words still allocated above endPointer: 0 != 192]`).
  - `src/lib/LibBytes32Array.sol` `truncate`: same mutation → killed by `testEndPointerDivergesAfterTruncate` (same message).
  - `src/lib/LibBytes.sol` `endAllocatedPointer`: `pointer := add(data, and(add(add(mload(data), 0x20), 0x1f), not(0x1f)))` → `add(data, add(mload(data), 0x20))` → killed by `testEndAllocatedPointerDivergesAfterTruncate` (`[FAIL: untruncated: end of the allocation: 1160 != 1184]`).
  - Each mutant was grep-confirmed applied to the source before its run, after a first attempt with a line-range `sed` silently patched nothing and reported four false survivors.
- Oracle: the Solidity memory layout, not the library under test. Expected addresses come from where the allocator must put things — a `new` matrix allocates its pointer array before its inner arrays, `matrixFrom` wraps arrays that already exist — cross-checked against `LibPointer.allocatedMemoryPointer()` (the free memory pointer at 0x40, Solidity's own record of the allocation, computed without any of `endPointer`'s arithmetic) and against `startPointer` of the inner arrays. The corruption case's oracle is the observed effect: `matrix[0].length` read back after the write.
- Category check: issue asks (A) matrix `endPointer` NatSpec falsely claims the end of allocated memory and hides a corruption hazard, (B) the array libraries' `endPointer` carries a milder version of the same defect because `truncate` shrinks the length word, (C) `LibBytes.endAllocatedPointer` has the identical problem and `LibBytes.t.sol:85-98` bakes it in, (D) `LibBytes.endDataPointer`'s `@return` claims what `endAllocatedPointer` returns. Covered A, B, C, D — the issue's proposed fix is docs-only on all four, and this establishes from the code why (a matrix has no contiguous allocation, so no value of `endPointer` satisfies the old wording) and pins each new doc claim with a test rather than leaving prose nothing checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
