### PR TITLE
Read the tail length before writing the output length word

### DIFF
--- a/src/lib/LibBytes32Array.sol
+++ b/src/lib/LibBytes32Array.sol
@@ -239,7 +239,15 @@ library LibBytes32Array {
     /// @return array The new array.
     function arrayFrom(bytes32 a, bytes32[] memory tail) internal pure returns (bytes32[] memory array) {
         assembly ("memory-safe") {
-            let length := add(mload(tail), 1)
+            // Read the tail length ONCE, before anything is written into the
+            // output region. The output is allocated at the free memory
+            // pointer, so a tail at or above it overlaps the output and the
+            // writes below can land on the tail's own length word. Reading the
+            // length again after that would size the copy from a word the
+            // function itself just wrote, running it past the free memory
+            // pointer.
+            let tailLength := mload(tail)
+            let length := add(tailLength, 1)
             let outputCursor := mload(0x40)
             array := outputCursor
             let outputEnd := add(outputCursor, add(0x20, mul(length, 0x20)))
@@ -248,7 +256,7 @@ library LibBytes32Array {
             mstore(outputCursor, length)
             mstore(add(outputCursor, 0x20), a)
 
-            mcopy(add(outputCursor, 0x40), add(tail, 0x20), mul(mload(tail), 0x20))
+            mcopy(add(outputCursor, 0x40), add(tail, 0x20), mul(tailLength, 0x20))
         }
     }
 
@@ -260,7 +268,15 @@ library LibBytes32Array {
     /// @return array The new array.
     function arrayFrom(bytes32 a, bytes32 b, bytes32[] memory tail) internal pure returns (bytes32[] memory array) {
         assembly ("memory-safe") {
-            let length := add(mload(tail), 2)
+            // Read the tail length ONCE, before anything is written into the
+            // output region. The output is allocated at the free memory
+            // pointer, so a tail at or above it overlaps the output and the
+            // writes below can land on the tail's own length word. Reading the
+            // length again after that would size the copy from a word the
+            // function itself just wrote, running it past the free memory
+            // pointer.
+            let tailLength := mload(tail)
+            let length := add(tailLength, 2)
             let outputCursor := mload(0x40)
             array := outputCursor
             let outputEnd := add(outputCursor, add(0x20, mul(length, 0x20)))
@@ -270,7 +286,7 @@ library LibBytes32Array {
             mstore(add(outputCursor, 0x20), a)
             mstore(add(outputCursor, 0x40), b)
 
-            mcopy(add(outputCursor, 0x60), add(tail, 0x20), mul(mload(tail), 0x20))
+            mcopy(add(outputCursor, 0x60), add(tail, 0x20), mul(tailLength, 0x20))
         }
     }
 

--- a/src/lib/LibUint256Array.sol
+++ b/src/lib/LibUint256Array.sol
@@ -239,7 +239,15 @@ library LibUint256Array {
     /// @return array The new array.
     function arrayFrom(uint256 a, uint256[] memory tail) internal pure returns (uint256[] memory array) {
         assembly ("memory-safe") {
-            let length := add(mload(tail), 1)
+            // Read the tail length ONCE, before anything is written into the
+            // output region. The output is allocated at the free memory
+            // pointer, so a tail at or above it overlaps the output and the
+            // writes below can land on the tail's own length word. Reading the
+            // length again after that would size the copy from a word the
+            // function itself just wrote, running it past the free memory
+            // pointer.
+            let tailLength := mload(tail)
+            let length := add(tailLength, 1)
             let outputCursor := mload(0x40)
             array := outputCursor
             let outputEnd := add(outputCursor, add(0x20, mul(length, 0x20)))
@@ -248,7 +256,7 @@ library LibUint256Array {
             mstore(outputCursor, length)
             mstore(add(outputCursor, 0x20), a)
 
-            mcopy(add(outputCursor, 0x40), add(tail, 0x20), mul(mload(tail), 0x20))
+            mcopy(add(outputCursor, 0x40), add(tail, 0x20), mul(tailLength, 0x20))
         }
     }
 
@@ -260,7 +268,15 @@ library LibUint256Array {
     /// @return array The new array.
     function arrayFrom(uint256 a, uint256 b, uint256[] memory tail) internal pure returns (uint256[] memory array) {
         assembly ("memory-safe") {
-            let length := add(mload(tail), 2)
+            // Read the tail length ONCE, before anything is written into the
+            // output region. The output is allocated at the free memory
+            // pointer, so a tail at or above it overlaps the output and the
+            // writes below can land on the tail's own length word. Reading the
+            // length again after that would size the copy from a word the
+            // function itself just wrote, running it past the free memory
+            // pointer.
+            let tailLength := mload(tail)
+            let length := add(tailLength, 2)
             let outputCursor := mload(0x40)
             array := outputCursor
             let outputEnd := add(outputCursor, add(0x20, mul(length, 0x20)))
@@ -270,7 +286,7 @@ library LibUint256Array {
             mstore(add(outputCursor, 0x20), a)
             mstore(add(outputCursor, 0x40), b)
 
-            mcopy(add(outputCursor, 0x60), add(tail, 0x20), mul(mload(tail), 0x20))
+            mcopy(add(outputCursor, 0x60), add(tail, 0x20), mul(tailLength, 0x20))
         }
     }
 

--- a/test/src/lib/LibArray.aliasedTail.t.sol
+++ b/test/src/lib/LibArray.aliasedTail.t.sol
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {LibUint256Array} from "src/lib/LibUint256Array.sol";
+import {LibBytes32Array} from "src/lib/LibBytes32Array.sol";
+
+/// The tail taking `arrayFrom` overloads allocate their output at the free
+/// memory pointer and read the tail's length word to size the copy. A tail that
+/// sits at the free memory pointer, which is what `unsafeAsUint256Array` and
+/// `unsafeAsBytes32Array` over hand managed memory produce, shares that word
+/// with the output's length prefix, so the read has to happen before the output
+/// length is written.
+///
+/// The assembly is annotated `("memory-safe")`, which promises the compiler
+/// nothing is written at or above the free memory pointer the block leaves.
+/// Canaries planted above the reserved region must survive.
+contract LibArrayAliasedTailTest is Test {
+    /// `arrayFrom(a, tail)` reserves a length word plus four items for a three
+    /// item tail, so the output ends `0xA0` above the free memory pointer and
+    /// the canary is the first word past it.
+    function testArrayFromATailUint256WritesNothingAboveFreeMemoryPointer() external pure {
+        uint256[] memory tail;
+        uint256 canaryPointer;
+        // Deliberately NOT ("memory-safe"): this builds the tail at the free
+        // memory pointer without moving it, and plants a canary above the
+        // region the call reserves. Claiming memory-safe here would let the
+        // optimizer assume those words are untouched and fold the read below
+        // into a constant, so the test could pass even after a regression.
+        assembly {
+            let fmp := mload(0x40)
+            mstore(fmp, 3)
+            mstore(add(fmp, 0x20), 0x11)
+            mstore(add(fmp, 0x40), 0x22)
+            mstore(add(fmp, 0x60), 0x33)
+            tail := fmp
+            canaryPointer := add(fmp, 0xA0)
+            mstore(canaryPointer, 0xdead0001)
+        }
+
+        uint256[] memory array = LibUint256Array.arrayFrom(0xFF, tail);
+
+        // Read the canary before anything else, as the free memory pointer now
+        // points at it and any allocation would overwrite it legitimately.
+        uint256 canary;
+        assembly {
+            canary := mload(canaryPointer)
+        }
+        assertEq(canary, 0xdead0001, "wrote at or above the free memory pointer");
+        assertEq(array.length, 4, "length is the tail length plus the head");
+    }
+
+    /// `arrayFrom(a, b, tail)` reserves a length word plus five items for a
+    /// three item tail, so the output ends `0xC0` above the free memory pointer
+    /// and the double read overruns it by two words.
+    function testArrayFromABTailUint256WritesNothingAboveFreeMemoryPointer() external pure {
+        uint256[] memory tail;
+        uint256 canaryPointer;
+        // Deliberately NOT ("memory-safe") -- see above.
+        assembly {
+            let fmp := mload(0x40)
+            mstore(fmp, 3)
+            mstore(add(fmp, 0x20), 0x11)
+            mstore(add(fmp, 0x40), 0x22)
+            mstore(add(fmp, 0x60), 0x33)
+            tail := fmp
+            canaryPointer := add(fmp, 0xC0)
+            mstore(canaryPointer, 0xdead0001)
+            mstore(add(canaryPointer, 0x20), 0xdead0002)
+        }
+
+        uint256[] memory array = LibUint256Array.arrayFrom(0xFF, 0xEE, tail);
+
+        uint256 canary1;
+        uint256 canary2;
+        assembly {
+            canary1 := mload(canaryPointer)
+            canary2 := mload(add(canaryPointer, 0x20))
+        }
+        assertEq(canary1, 0xdead0001, "wrote at or above the free memory pointer");
+        assertEq(canary2, 0xdead0002, "wrote at or above the free memory pointer");
+        assertEq(array.length, 5, "length is the tail length plus the two heads");
+    }
+
+    function testArrayFromATailBytes32WritesNothingAboveFreeMemoryPointer() external pure {
+        bytes32[] memory tail;
+        uint256 canaryPointer;
+        // Deliberately NOT ("memory-safe") -- see above.
+        assembly {
+            let fmp := mload(0x40)
+            mstore(fmp, 3)
+            mstore(add(fmp, 0x20), 0x11)
+            mstore(add(fmp, 0x40), 0x22)
+            mstore(add(fmp, 0x60), 0x33)
+            tail := fmp
+            canaryPointer := add(fmp, 0xA0)
+            mstore(canaryPointer, 0xdead0001)
+        }
+
+        bytes32[] memory array = LibBytes32Array.arrayFrom(bytes32(uint256(0xFF)), tail);
+
+        uint256 canary;
+        assembly {
+            canary := mload(canaryPointer)
+        }
+        assertEq(canary, 0xdead0001, "wrote at or above the free memory pointer");
+        assertEq(array.length, 4, "length is the tail length plus the head");
+    }
+
+    function testArrayFromABTailBytes32WritesNothingAboveFreeMemoryPointer() external pure {
+        bytes32[] memory tail;
+        uint256 canaryPointer;
+        // Deliberately NOT ("memory-safe") -- see above.
+        assembly {
+            let fmp := mload(0x40)
+            mstore(fmp, 3)
+            mstore(add(fmp, 0x20), 0x11)
+            mstore(add(fmp, 0x40), 0x22)
+            mstore(add(fmp, 0x60), 0x33)
+            tail := fmp
+            canaryPointer := add(fmp, 0xC0)
+            mstore(canaryPointer, 0xdead0001)
+            mstore(add(canaryPointer, 0x20), 0xdead0002)
+        }
+
+        bytes32[] memory array = LibBytes32Array.arrayFrom(bytes32(uint256(0xFF)), bytes32(uint256(0xEE)), tail);
+
+        uint256 canary1;
+        uint256 canary2;
+        assembly {
+            canary1 := mload(canaryPointer)
+            canary2 := mload(add(canaryPointer, 0x20))
+        }
+        assertEq(canary1, 0xdead0001, "wrote at or above the free memory pointer");
+        assertEq(canary2, 0xdead0002, "wrote at or above the free memory pointer");
+        assertEq(array.length, 5, "length is the tail length plus the two heads");
+    }
+}


### PR DESCRIPTION
Closes #66

Both tail taking `arrayFrom` overloads read `mload(tail)` **twice**: once to size
the reservation, once to size the copy. Between the two reads the function writes
the output's own length word at the free memory pointer. A `tail` at or above the
free memory pointer overlaps that output, so read 2 returns a word the function
itself just wrote, and the `mcopy` runs past the free memory pointer the block
had just set.

```diff
-            let length := add(mload(tail), 1)
+            let tailLength := mload(tail)
+            let length := add(tailLength, 1)
             let outputCursor := mload(0x40)
             array := outputCursor
             let outputEnd := add(outputCursor, add(0x20, mul(length, 0x20)))
             mstore(0x40, outputEnd)

             mstore(outputCursor, length)
             mstore(add(outputCursor, 0x20), a)

-            mcopy(add(outputCursor, 0x40), add(tail, 0x20), mul(mload(tail), 0x20))
+            mcopy(add(outputCursor, 0x40), add(tail, 0x20), mul(tailLength, 0x20))
```

Applied to all four sites — `arrayFrom(a, tail)` and `arrayFrom(a, b, tail)` in
both `LibUint256Array` and `LibBytes32Array`, which carried the identical
pattern. Same fix shape #57 took for `unsafeExtend`.

## Why it matters

`("memory-safe")` is a contract with the **compiler**, not the caller — Solidity
relies on it for stack-to-memory and via-IR spilling, and neither the `unsafe`
prefix on the construction path nor a NatSpec caveat can waive it. For a three
item tail sitting exactly at the free memory pointer the copy overran the
reservation by `0x20` bytes in the one head overload and `0x40` bytes in the two
head overload.

## Evidence

New `test/src/lib/LibArray.aliasedTail.t.sol` builds a three item tail at the
free memory pointer — what `unsafeAsUint256Array` / `unsafeAsBytes32Array` over
hand managed memory produce — plants canaries in the words the overrun reaches,
and reads them back immediately after the call, before any assertion can
legitimately allocate over them.

| test | on base `src/` | with fix |
|---|---|---|
| `testArrayFromATailUint256WritesNothingAboveFreeMemoryPointer` | **FAIL** `0 != 3735879681` | PASS |
| `testArrayFromABTailUint256WritesNothingAboveFreeMemoryPointer` | **FAIL** `0 != 3735879681` | PASS |
| `testArrayFromATailBytes32WritesNothingAboveFreeMemoryPointer` | **FAIL** `0 != 3735879681` | PASS |
| `testArrayFromABTailBytes32WritesNothingAboveFreeMemoryPointer` | **FAIL** `0 != 3735879681` | PASS |

Verified by `git checkout origin/main -- src/lib/LibUint256Array.sol
src/lib/LibBytes32Array.sol` and re-running the whole suite with the new test
file in place: `350 tests passed, 4 failed`.

The canary tests are the discriminating ones. Contents assertions cannot detect
this: with an aliasing tail the returned contents are the same before and after
the fix, because the head write lands on `tail[0]` either way. The `array.length`
assertions in each test are invariants that hold on both sides — they keep the
call live, they are not evidence.

Whole suite: **354 passing** (350 baseline + 4), 0 failed.

## What this does NOT fix

With an aliasing tail `arrayFrom` still mutates the tail — the length write lands
on the tail's length word and the head write on `tail[0]`, because they are the
same words. That is inherent to the aliasing and no reordering fixes it. The
existing `testArrayFromATail` asserts `"tail mutated"` only for a disjoint tail,
and the NatSpec says nothing either way. It is the same open question #61 raises
for `unsafeExtend`'s NatSpec, and I have deliberately not picked an answer here
rather than widen this PR.

## Audit drift

`rain.solmem` is Protofire audited at `228b35c6`. This adds 8 lines of code
(4 hoisted reads, 4 rewritten copy sizes) plus comments to the audited source, on
top of the drift #57 and #100/#101 already carry.

## QA

- **Discriminating tests**: `testArrayFromATailUint256WritesNothingAboveFreeMemoryPointer`,
  `testArrayFromABTailUint256WritesNothingAboveFreeMemoryPointer`,
  `testArrayFromATailBytes32WritesNothingAboveFreeMemoryPointer`,
  `testArrayFromABTailBytes32WritesNothingAboveFreeMemoryPointer` — each fails on
  base `src/` (verified by `git checkout origin/main -- src/lib/LibUint256Array.sol
  src/lib/LibBytes32Array.sol` with the new test file in place, whole suite
  `350 passed, 4 failed`, all four failures being exactly these).
- **Mutations applied** (`mutation-probe`, whole repo suite per verdict, baseline
  green at 354; **6/6 KILLED, 0 survived, 0 no-run, 0 harness errors**):
  - M01 `LibUint256Array.sol` `mcopy(add(outputCursor, 0x40), …, mul(tailLength, 0x20))` → `mul(mload(tail), 0x20)` → killed by `testArrayFromATailUint256WritesNothingAboveFreeMemoryPointer`
  - M02 `LibUint256Array.sol` `mcopy(add(outputCursor, 0x60), …, mul(tailLength, 0x20))` → `mul(mload(tail), 0x20)` → killed by `testArrayFromABTailUint256WritesNothingAboveFreeMemoryPointer`
  - M03 `LibBytes32Array.sol` `mcopy(add(outputCursor, 0x40), …, mul(tailLength, 0x20))` → `mul(mload(tail), 0x20)` → killed by `testArrayFromATailBytes32WritesNothingAboveFreeMemoryPointer`
  - M04 `LibBytes32Array.sol` `mcopy(add(outputCursor, 0x60), …, mul(tailLength, 0x20))` → `mul(mload(tail), 0x20)` → killed by `testArrayFromABTailBytes32WritesNothingAboveFreeMemoryPointer`
  - M05 `LibUint256Array.sol` `outputEnd := add(outputCursor, add(0x20, mul(length, 0x20)))` → `mul(tailLength, 0x20)` (under-reserve one word) → killed by the pre-existing `testArrayFromATail`
  - M06 `LibBytes32Array.sol` same under-reserve in the two head overload → killed by the pre-existing `testArrayFromABTail`
  
  M05/M06 exist to credit rather than assume the pre-existing `arrayFrom` tests
  over the reservation the hoisted read also feeds.
- **Oracle**: the `("memory-safe")` annotation itself — the compiler is promised
  nothing is written at or above the free memory pointer the block leaves. Canary
  words are planted at addresses computed by hand from the reservation arithmetic
  (`outputEnd = fmp + 0x20 + (tailLength + heads) * 0x20`), not read back from the
  implementation, and the canary blocks are deliberately **not** annotated
  memory-safe so the optimizer cannot fold the read into a constant.
- **Category check**: #66 names four sites — `LibUint256Array.sol` `:242/251` and
  `:263/273`, `LibBytes32Array.sol` `:242/251` and `:263/273`. All four fixed and
  all four covered by a discriminating test and a mutant. I re-verified the
  premise against `origin/main` at `e8cb007` before starting: all four double
  reads were still present. `LibUint256Matrix` / `LibBytes32Matrix` have no
  tail-taking `matrixFrom` overload, so the category does not extend there.
