### PR TITLE
Route unsafeExtend's aliased case through the allocating path

### DIFF
--- a/src/lib/LibBytes32Array.sol
+++ b/src/lib/LibBytes32Array.sol
@@ -315,7 +315,9 @@ library LibBytes32Array {
     /// optimisation reasons. To use this function safely THE CALLER MUST NOT USE
     /// THE BASE ARRAY AND MUST USE THE RETURNED ARRAY ONLY. It is safe to use
     /// the extend array after calling this function as it is never mutated, it
-    /// is only copied from.
+    /// is only copied from. Extending an array by itself therefore always
+    /// allocates, as the in place path would rewrite the length word that base
+    /// and extend share.
     ///
     /// @param b The base integer array that will be extended by `e`.
     /// @param e The extend integer array that extends `b`.
@@ -331,9 +333,16 @@ library LibBytes32Array {
                 let baseLength := mload(base)
                 let baseEnd := add(base, add(0x20, mul(baseLength, 0x20)))
 
-                // If base is NOT the last thing in allocated memory, allocate,
-                // copy and recurse.
-                switch eq(outputCursor, baseEnd)
+                // The in place path rewrites base's length word where it sits,
+                // and when extend IS base that word is also extend's length
+                // word, so the write would mutate extend. The in place path is
+                // therefore only taken when base is the last thing in allocated
+                // memory AND extend is a different array. Otherwise allocate,
+                // copy and recurse. The copy puts base above every existing
+                // allocation, where it is both the last allocation and distinct
+                // from extend, so the recursion is one deep and lands on the in
+                // place path.
+                switch and(eq(outputCursor, baseEnd), iszero(eq(base, extend)))
                 case 0 {
                     let newBase := outputCursor
                     // Base size includes the length word and is in bytes.
@@ -345,11 +354,9 @@ library LibBytes32Array {
                     baseAfter := extendInline(newBase, extend)
                 }
                 case 1 {
-                    // Read the extend length ONCE, before base's length word is
-                    // overwritten. When extend aliases base they are the same
-                    // word, so re-reading it after the write yields the already
-                    // combined length and the copy runs past the free memory
-                    // pointer.
+                    // The extend length is read ONCE, before base's length word
+                    // is overwritten, so the copy size never depends on the
+                    // order of the read and the write.
                     let extendLength := mload(extend)
                     let totalLength := add(baseLength, extendLength)
                     let outputEnd := add(base, add(0x20, mul(totalLength, 0x20)))

--- a/src/lib/LibBytes32Array.sol
+++ b/src/lib/LibBytes32Array.sol
@@ -319,6 +319,9 @@ library LibBytes32Array {
     /// allocates, as the in place path would rewrite the length word that base
     /// and extend share.
     ///
+    /// Both arrays MUST be valid solidity memory arrays, each owning the region
+    /// its own length word describes.
+    ///
     /// @param b The base integer array that will be extended by `e`.
     /// @param e The extend integer array that extends `b`.
     /// @return extended The extended array of `b` extended by `e`.

--- a/src/lib/LibUint256Array.sol
+++ b/src/lib/LibUint256Array.sol
@@ -319,6 +319,9 @@ library LibUint256Array {
     /// allocates, as the in place path would rewrite the length word that base
     /// and extend share.
     ///
+    /// Both arrays MUST be valid solidity memory arrays, each owning the region
+    /// its own length word describes.
+    ///
     /// @param b The base integer array that will be extended by `e`.
     /// @param e The extend integer array that extends `b`.
     /// @return extended The extended array of `b` extended by `e`.

--- a/src/lib/LibUint256Array.sol
+++ b/src/lib/LibUint256Array.sol
@@ -315,7 +315,9 @@ library LibUint256Array {
     /// optimisation reasons. To use this function safely THE CALLER MUST NOT USE
     /// THE BASE ARRAY AND MUST USE THE RETURNED ARRAY ONLY. It is safe to use
     /// the extend array after calling this function as it is never mutated, it
-    /// is only copied from.
+    /// is only copied from. Extending an array by itself therefore always
+    /// allocates, as the in place path would rewrite the length word that base
+    /// and extend share.
     ///
     /// @param b The base integer array that will be extended by `e`.
     /// @param e The extend integer array that extends `b`.
@@ -331,9 +333,16 @@ library LibUint256Array {
                 let baseLength := mload(base)
                 let baseEnd := add(base, add(0x20, mul(baseLength, 0x20)))
 
-                // If base is NOT the last thing in allocated memory, allocate,
-                // copy and recurse.
-                switch eq(outputCursor, baseEnd)
+                // The in place path rewrites base's length word where it sits,
+                // and when extend IS base that word is also extend's length
+                // word, so the write would mutate extend. The in place path is
+                // therefore only taken when base is the last thing in allocated
+                // memory AND extend is a different array. Otherwise allocate,
+                // copy and recurse. The copy puts base above every existing
+                // allocation, where it is both the last allocation and distinct
+                // from extend, so the recursion is one deep and lands on the in
+                // place path.
+                switch and(eq(outputCursor, baseEnd), iszero(eq(base, extend)))
                 case 0 {
                     let newBase := outputCursor
                     // Base size includes the length word and is in bytes.
@@ -345,11 +354,9 @@ library LibUint256Array {
                     baseAfter := extendInline(newBase, extend)
                 }
                 case 1 {
-                    // Read the extend length ONCE, before base's length word is
-                    // overwritten. When extend aliases base they are the same
-                    // word, so re-reading it after the write yields the already
-                    // combined length and the copy runs past the free memory
-                    // pointer.
+                    // The extend length is read ONCE, before base's length word
+                    // is overwritten, so the copy size never depends on the
+                    // order of the read and the write.
                     let extendLength := mload(extend)
                     let totalLength := add(baseLength, extendLength)
                     let outputEnd := add(base, add(0x20, mul(totalLength, 0x20)))

--- a/test/src/lib/LibArray.selfExtend.t.sol
+++ b/test/src/lib/LibArray.selfExtend.t.sol
@@ -6,45 +6,83 @@ import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibUint256Array} from "src/lib/LibUint256Array.sol";
 import {LibBytes32Array} from "src/lib/LibBytes32Array.sol";
 
-/// Extending an array by itself. The inline path reads the extend length for
-/// the copy size, and when extend aliases base that read has to happen before
-/// base's length word is rewritten.
+/// Extending an array by itself. Base and extend are then ONE array, so the in
+/// place path would rewrite the length word both of them read through, mutating
+/// the extend array that the NatSpec promises is only ever copied from. Self
+/// extension therefore allocates: the input array is left exactly as it was and
+/// the doubled result is a new region.
 contract LibArraySelfExtendTest is Test {
     using LibUint256Array for uint256[];
     using LibBytes32Array for bytes32[];
 
-    /// The assembly is annotated ("memory-safe"), which promises the compiler
-    /// nothing is written at or above the free memory pointer the block leaves.
-    /// Canaries planted above it must survive.
-    function testSelfExtendUint256WritesNothingAboveFreeMemoryPointer() external pure {
+    /// Words of free memory poisoned above the free memory pointer.
+    uint256 internal constant POISON_WORDS = 12;
+
+    /// Every poisoned word that lies at or above the FINAL free memory pointer
+    /// is still free memory and must therefore be untouched. Words below it
+    /// were allocated by the call and hold the extended array.
+    function _assertNothingWrittenPastFmp(uint256[POISON_WORDS] memory captured, uint256 fmpBefore, uint256 fmpAfter)
+        internal
+        pure
+    {
+        for (uint256 i = 0; i < POISON_WORDS; i++) {
+            if (fmpBefore + i * 0x20 < fmpAfter) {
+                continue;
+            }
+            assertEq(captured[i], 0xF00D0000 + i, "wrote past the free memory pointer");
+        }
+    }
+
+    /// The extend array is never mutated, and when base IS extend that is the
+    /// input array in its entirety: length word and every data word.
+    function testSelfExtendUint256LeavesTheArrayUnmutated() external pure {
         uint256[] memory a = new uint256[](3);
         a[0] = 0x11;
         a[1] = 0x22;
         a[2] = 0x33;
 
-        uint256 fmpBefore;
-        assembly ("memory-safe") {
-            fmpBefore := mload(0x40)
-        }
-        // Deliberately NOT ("memory-safe"): this writes above the free memory
-        // pointer on purpose. Claiming memory-safe here would let the optimizer
-        // assume the region is untouched and fold the read below into a
-        // constant, so the test could pass even after a regression.
-        assembly {
-            mstore(add(fmpBefore, 0x60), 0xdead0001)
-            mstore(add(fmpBefore, 0xa0), 0xdead0002)
-        }
-
         a.unsafeExtend(a);
 
-        uint256 canary1;
-        uint256 canary2;
+        // Deliberately NOT ("memory-safe"): the array is read back out of raw
+        // memory so the optimizer answers from memory as it stands after the
+        // call rather than from the values written above.
+        uint256 lengthAfter;
+        uint256 word0;
+        uint256 word1;
+        uint256 word2;
         assembly {
-            canary1 := mload(add(fmpBefore, 0x60))
-            canary2 := mload(add(fmpBefore, 0xa0))
+            lengthAfter := mload(a)
+            word0 := mload(add(a, 0x20))
+            word1 := mload(add(a, 0x40))
+            word2 := mload(add(a, 0x60))
         }
-        assertEq(canary1, 0xdead0001, "wrote at or above the free memory pointer");
-        assertEq(canary2, 0xdead0002, "wrote at or above the free memory pointer");
+
+        assertEq(lengthAfter, 3, "length word mutated");
+        assertEq(word0, 0x11, "0");
+        assertEq(word1, 0x22, "1");
+        assertEq(word2, 0x33, "2");
+    }
+
+    /// Leaving the array unmutated is only possible by returning a different
+    /// region, so the returned pointer must differ from the one passed in even
+    /// though the base array is the most recent allocation.
+    function testSelfExtendUint256AllocatesRatherThanExtendingInPlace() external pure {
+        uint256[] memory a = new uint256[](3);
+        a[0] = 0x11;
+        a[1] = 0x22;
+        a[2] = 0x33;
+
+        uint256[] memory extended = a.unsafeExtend(a);
+
+        // Deliberately NOT ("memory-safe") — see above.
+        uint256 aPointer;
+        uint256 extendedPointer;
+        assembly {
+            aPointer := a
+            extendedPointer := extended
+        }
+
+        assertTrue(extendedPointer != aPointer, "extended in place");
     }
 
     /// Self-extension copies the original elements once, so the result is the
@@ -66,28 +104,113 @@ contract LibArraySelfExtendTest is Test {
         assertEq(extended[5], 0x33);
     }
 
-    function testSelfExtendBytes32WritesNothingAboveFreeMemoryPointer() external pure {
+    /// The free memory pointer must end up EXACTLY at the end of the extended
+    /// array. The allocating path allocates twice, once for the copy of base
+    /// and once for the extension on top of it, and the second allocation must
+    /// subsume the first rather than sit on top of it.
+    function testSelfExtendUint256AllocatesExactly() external pure {
+        uint256[] memory a = new uint256[](3);
+        a[0] = 0x11;
+        a[1] = 0x22;
+        a[2] = 0x33;
+
+        uint256[] memory extended = a.unsafeExtend(a);
+        // Read the free memory pointer IMMEDIATELY after the call under test.
+        // Assertions allocate, so any assertion made first moves the pointer
+        // and destroys the measurement.
+        uint256 fmpAfter;
+        uint256 endOfExtended;
+        assembly {
+            fmpAfter := mload(0x40)
+            endOfExtended := add(extended, add(0x20, mul(mload(extended), 0x20)))
+        }
+
+        assertEq(extended.length, 6, "length");
+        assertEq(fmpAfter, endOfExtended, "fmp must sit exactly at the end of the extended array");
+    }
+
+    /// The assembly is annotated ("memory-safe"), which promises the compiler
+    /// nothing is written at or above the free memory pointer the block leaves.
+    /// Self extension allocates, so the words it writes are below that pointer;
+    /// poison at or above it must survive.
+    function testSelfExtendUint256WritesNothingAboveFreeMemoryPointer() external pure {
+        uint256[POISON_WORDS] memory captured;
+
+        uint256[] memory a = new uint256[](3);
+        a[0] = 0x11;
+        a[1] = 0x22;
+        a[2] = 0x33;
+
+        // Poison, then the call under test, then snapshot and capture. The two
+        // assembly blocks sit flush against the call so the only boundary the
+        // poison crosses is the call being measured. Deliberately NOT
+        // ("memory-safe"): this writes above the free memory pointer on
+        // purpose, and claiming memory safety here would let the optimizer
+        // assume the region is untouched and fold the reads below into
+        // constants, so the test could pass even after a regression.
+        uint256 fmpBefore;
+        assembly {
+            fmpBefore := mload(0x40)
+            for { let i := 0 } lt(i, POISON_WORDS) { i := add(i, 1) } {
+                mstore(add(fmpBefore, mul(i, 0x20)), add(0xF00D0000, i))
+            }
+        }
+        uint256[] memory extended = a.unsafeExtend(a);
+        uint256 fmpAfter;
+        assembly {
+            fmpAfter := mload(0x40)
+            for { let i := 0 } lt(i, POISON_WORDS) { i := add(i, 1) } {
+                mstore(add(captured, mul(i, 0x20)), mload(add(fmpBefore, mul(i, 0x20))))
+            }
+        }
+
+        assertEq(extended.length, 6, "length");
+        _assertNothingWrittenPastFmp(captured, fmpBefore, fmpAfter);
+    }
+
+    function testSelfExtendBytes32LeavesTheArrayUnmutated() external pure {
         bytes32[] memory a = new bytes32[](3);
         a[0] = bytes32(uint256(0x11));
         a[1] = bytes32(uint256(0x22));
         a[2] = bytes32(uint256(0x33));
 
-        uint256 fmpBefore;
-        assembly ("memory-safe") {
-            fmpBefore := mload(0x40)
-        }
-        // Deliberately NOT ("memory-safe") — see above.
-        assembly {
-            mstore(add(fmpBefore, 0x60), 0xdead0001)
-        }
-
         a.unsafeExtend(a);
 
-        uint256 canary1;
+        // Deliberately NOT ("memory-safe") — see above.
+        uint256 lengthAfter;
+        uint256 word0;
+        uint256 word1;
+        uint256 word2;
         assembly {
-            canary1 := mload(add(fmpBefore, 0x60))
+            lengthAfter := mload(a)
+            word0 := mload(add(a, 0x20))
+            word1 := mload(add(a, 0x40))
+            word2 := mload(add(a, 0x60))
         }
-        assertEq(canary1, 0xdead0001, "wrote at or above the free memory pointer");
+
+        assertEq(lengthAfter, 3, "length word mutated");
+        assertEq(word0, 0x11, "0");
+        assertEq(word1, 0x22, "1");
+        assertEq(word2, 0x33, "2");
+    }
+
+    function testSelfExtendBytes32AllocatesRatherThanExtendingInPlace() external pure {
+        bytes32[] memory a = new bytes32[](3);
+        a[0] = bytes32(uint256(0x11));
+        a[1] = bytes32(uint256(0x22));
+        a[2] = bytes32(uint256(0x33));
+
+        bytes32[] memory extended = a.unsafeExtend(a);
+
+        // Deliberately NOT ("memory-safe") — see above.
+        uint256 aPointer;
+        uint256 extendedPointer;
+        assembly {
+            aPointer := a
+            extendedPointer := extended
+        }
+
+        assertTrue(extendedPointer != aPointer, "extended in place");
     }
 
     function testSelfExtendBytes32DoublesTheContents() external pure {
@@ -102,5 +225,53 @@ contract LibArraySelfExtendTest is Test {
         assertEq(extended[1], bytes32(uint256(0xBB)));
         assertEq(extended[2], bytes32(uint256(0xAA)));
         assertEq(extended[3], bytes32(uint256(0xBB)));
+    }
+
+    function testSelfExtendBytes32AllocatesExactly() external pure {
+        bytes32[] memory a = new bytes32[](3);
+        a[0] = bytes32(uint256(0x11));
+        a[1] = bytes32(uint256(0x22));
+        a[2] = bytes32(uint256(0x33));
+
+        bytes32[] memory extended = a.unsafeExtend(a);
+        // Read the free memory pointer IMMEDIATELY after the call under test.
+        uint256 fmpAfter;
+        uint256 endOfExtended;
+        assembly {
+            fmpAfter := mload(0x40)
+            endOfExtended := add(extended, add(0x20, mul(mload(extended), 0x20)))
+        }
+
+        assertEq(extended.length, 6, "length");
+        assertEq(fmpAfter, endOfExtended, "fmp must sit exactly at the end of the extended array");
+    }
+
+    function testSelfExtendBytes32WritesNothingAboveFreeMemoryPointer() external pure {
+        uint256[POISON_WORDS] memory captured;
+
+        bytes32[] memory a = new bytes32[](3);
+        a[0] = bytes32(uint256(0x11));
+        a[1] = bytes32(uint256(0x22));
+        a[2] = bytes32(uint256(0x33));
+
+        // Poison, call, snapshot and capture — see above.
+        uint256 fmpBefore;
+        assembly {
+            fmpBefore := mload(0x40)
+            for { let i := 0 } lt(i, POISON_WORDS) { i := add(i, 1) } {
+                mstore(add(fmpBefore, mul(i, 0x20)), add(0xF00D0000, i))
+            }
+        }
+        bytes32[] memory extended = a.unsafeExtend(a);
+        uint256 fmpAfter;
+        assembly {
+            fmpAfter := mload(0x40)
+            for { let i := 0 } lt(i, POISON_WORDS) { i := add(i, 1) } {
+                mstore(add(captured, mul(i, 0x20)), mload(add(fmpBefore, mul(i, 0x20))))
+            }
+        }
+
+        assertEq(extended.length, 6, "length");
+        _assertNothingWrittenPastFmp(captured, fmpBefore, fmpAfter);
     }
 }


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.solmem/issues/61

The ruling on #61 is (c): route the aliased case through the allocating path so
the extend array is genuinely never mutated, restoring the NatSpec promise as
originally written. This is the code fix. It supersedes #115, which answered #61
by narrowing the promise in NatSpec instead.

## The change

`extendInline` took the in place path whenever base was the last thing in
allocated memory. When `extend` IS `base` that path rewrites the one length word
both arrays read through, so `unsafeExtend(a, a)` left `a.length` doubled — the
NatSpec sentence "it is safe to use the extend array after calling this function
as it is never mutated, it is only copied from" was false for that call.

Both libraries now gate the in place path on the arrays being distinct:

```solidity
switch and(eq(outputCursor, baseEnd), iszero(eq(base, extend)))
```

`base == extend` therefore falls into the existing allocate-copy-recurse branch.
That branch copies base to fresh memory above every existing allocation and
recurses, and the copy is distinct from `extend` by construction, so the
recursion is exactly one deep and lands on the in place path. The original array
is never written: `mstore(base, totalLength)` targets the copy, and the
extension `mcopy` writes above the free memory pointer, reading the original as
its source. The result is still the correct doubled array.

`#57`'s hoisted `mload(extend)` is kept.

Files: `src/lib/LibUint256Array.sol`, `src/lib/LibBytes32Array.sol`, identical
shape, plus `test/src/lib/LibArray.selfExtend.t.sol`.

## Red, then green

New tests against unmodified `main` source — the defect from the issue, with the
doubled length word measured directly:

```
[FAIL: length word mutated: 6 != 3] testSelfExtendUint256LeavesTheArrayUnmutated()
[FAIL: extended in place] testSelfExtendUint256AllocatesRatherThanExtendingInPlace()
[FAIL: length word mutated: 6 != 3] testSelfExtendBytes32LeavesTheArrayUnmutated()
[FAIL: extended in place] testSelfExtendBytes32AllocatesRatherThanExtendingInPlace()
Suite result: FAILED. 6 passed; 4 failed; 0 skipped
```

Same tests with the fix applied:

```
[PASS] testSelfExtendUint256LeavesTheArrayUnmutated() (gas: 1574)
[PASS] testSelfExtendUint256AllocatesRatherThanExtendingInPlace() (gas: 1202)
[PASS] testSelfExtendBytes32LeavesTheArrayUnmutated() (gas: 1613)
[PASS] testSelfExtendBytes32AllocatesRatherThanExtendingInPlace() (gas: 1194)
```

Whole suite: 332 passed / 0 failed before, 338 passed / 0 failed after.
`forge fmt --check` clean, `pre-commit run --all-files` clean, `slither .` 0
results.

## Two pre-existing tests were rewritten, not deleted

`testSelfExtendUint256WritesNothingAboveFreeMemoryPointer` and its `bytes32`
twin planted canaries at fixed offsets above the free memory pointer as it stood
BEFORE the call. That pins how far the in place path writes, i.e. which branch
self-extend takes, not a safety property. With the fix they fail, because the
allocating branch legitimately allocates that memory:

```
[FAIL: wrote at or above the free memory pointer: 51 != 3735879681] testSelfExtendUint256WritesNothingAboveFreeMemoryPointer()
[FAIL: wrote at or above the free memory pointer: 51 != 3735879681] testSelfExtendBytes32WritesNothingAboveFreeMemoryPointer()
```

They now poison 12 words and assert only the words at or above the FINAL free
memory pointer are untouched, which is what the `("memory-safe")` annotation
actually promises and is branch-agnostic. That is the same shape as
`_assertNothingWrittenPastFmp` in `LibUint256Array.allocation.t.sol`. A new
`...AllocatesExactly` test per library pins the final pointer at exactly the end
of the extended array, so the second allocation has to subsume the first rather
than sit on top of it.

## Gas

`3` word base, `2` word extend, `3` word self-extend, measured through external
entry points with `--gas-report` (harness not committed).

| path | before | after | delta |
| --- | --- | --- | --- |
| in place, `uint256[]` | 737 | 752 | +15 |
| allocating, `uint256[]` | 920 | 950 | +30 |
| self-extend, `uint256[]` | 641 | 874 | +233 |
| in place, `bytes32[]` | 747 | 762 | +15 |
| allocating, `bytes32[]` | 921 | 951 | +30 |
| self-extend, `bytes32[]` | 664 | 897 | +233 |

+15 per `extendInline` frame is the added comparison; the allocating path pays
it twice because it recurses. Self-extend pays the comparison plus a full copy
of base, and so scales with base length rather than being constant. Nothing on
the hot path pays more than the comparison.

## What this covers, and what it does not

Covered: `base == extend`, the total-overlap end of the range and the case #61
names. The input array is left byte-identical — length word and every data word
— and the returned array is a new region.

NOT covered: partial overlap, where `base != extend` but the regions intersect.
An equality check cannot see it. Measured on THIS branch, with two uncommitted
probes, both of which assert the promise and fail:

- extend's header inside base's data with extend's tail running past base's end
  (the shape #115 measured): extend's third data word `0xE0` reads back `0x33`,
  overwritten by the extension copy. `[FAIL: P1: extend data mutated: 51 != 224]`
- both arrays entirely inside allocated memory, base's length word sitting in
  extend's data: `mstore(base, totalLength)` lands on `extend[1]`, which reads
  back `14` instead of `6`. `[FAIL: P2: extend data mutated: 14 != 6]`

So the NatSpec sentence is now true for every non-overlapping pair and for the
aliased pair, and remains false for partially overlapping pairs. Closing that
would mean replacing the equality comparison with a region-overlap test
(`lt(base, extendEnd)` and `lt(extend, baseEnd)`), which costs an extra load,
multiply and add on the hot path to compute `extendEnd`. That is a separate
decision and is not in this PR. No test asserts the partial-overlap behaviour,
because a test asserting corrupted data would enshrine it.

## Audited source

`rain.solmem` is Protofire-audited at `228b35c6`. This changes audited runtime
behaviour and adds drift on top of #57's, which the ruling settles: audits are
commit-pinned, consumers pin versions, and publishing a new tag is the normal
path.

## Consumer-visible behaviour change

`unsafeExtend(a, a)` now returns a pointer that differs from `a` and leaves `a`
alone. Callers already had to use the returned array only, so a caller obeying
the NatSpec sees the same contents at the same length. A caller that read
`a.length` after self-extending saw `6` and now sees `3`.

## QA

- Discriminating tests: `testSelfExtend{Uint256,Bytes32}LeavesTheArrayUnmutated`
  and `testSelfExtend{Uint256,Bytes32}AllocatesRatherThanExtendingInPlace`, all
  four failing on unmodified `main` source with the transcript above and passing
  with the fix. Both read back through non-`("memory-safe")` assembly so the
  optimizer cannot answer from the values written before the call.
- Oracle: the EVM memory model, not the implementation. A 3 word array
  self-extended must still read length 3 afterwards because "never mutated"
  admits no write to that word, and it must read the doubled contents through
  the returned pointer.
- Mutations applied to `src/lib/LibUint256Array.sol` and
  `src/lib/LibBytes32Array.sol`, each reverted with `git checkout -- src`:
  - `switch and(eq(outputCursor, baseEnd), iszero(eq(base, extend)))` →
    `switch eq(outputCursor, baseEnd)`, i.e. the whole fix reverted. Killed by
    the 4 new tests, which is the red run transcribed above.
  - → `switch iszero(eq(base, extend))`, i.e. the "base is the last allocation"
    half dropped. Killed 12 times by `testExtendAllocate`,
    `testExtendAllocateDebug` and `testExtendAllocateEmptyExtendMovesBasePointer`
    across both libraries: `allocate path not taken`.
  - → `iszero(eq(mload(base), mload(extend)))`, i.e. comparing lengths instead
    of pointers. Killed by all 10 self-extension tests with `EvmError`: the copy
    has the same length as the array it was copied from, so the recursion never
    terminates.
  - `mcopy(baseEnd, add(extend, 0x20), mul(extendLength, 0x20))` →
    `mul(add(extendLength, 1), 0x20)`, one word too long. Killed by exactly the
    two rewritten `...WritesNothingAboveFreeMemoryPointer` tests
    (`wrote past the free memory pointer: 6 != 4027383815`), which is the
    protection the fixed-offset canaries used to provide.
- Category check: the issue asks for a ruling between (a) scope the promise and
  (b) reject aliasing; the ruling took (c), which #115 had listed and rejected.
  The aliased case named in the issue is fixed in code. The residual
  partial-overlap gap is stated above rather than papered over.
