### PR TITLE
README: drop the shell task list, fix the REUSE lint command

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,23 +50,6 @@ forge soldeer install # install dependencies declared in foundry.toml
 forge test
 ```
 
-Tasks in the shell:
-
-- `forge build` — compile.
-- `forge test` — the test suite.
-- `forge fmt --check` — formatting.
-- `slither .` — static analysis, config in `slither.config.json`.
-- `reuse lint` — REUSE compliance.
-
-CI runs all of those except `forge build`, plus `rainix-sol-single-contract`,
-which this repo's pinned rainix does not provide.
-
-`rainix-sol-artifacts` is on `PATH` too and is not a build. It runs
-`forge selectors up --all` against the public selector registry, then
-`forge script script/Deploy.sol` against `$ETH_RPC_URL` signed with
-`DEPLOYMENT_KEY`, broadcasting when `DEPLOY_BROADCAST` is set. There is no
-`script/` directory here. Do not run it.
-
 Use the nix-pinned `forge` for all development to keep versions consistent.
 
 ## Publish

--- a/README.md
+++ b/README.md
@@ -50,12 +50,22 @@ forge soldeer install # install dependencies declared in foundry.toml
 forge test
 ```
 
-Tasks exposed via the shell (delegate to rainix):
+Tasks in the shell:
 
-- `rainix-sol-test` — `forge test`
-- `rainix-sol-static` — slither
-- `rainix-sol-legal` — `reuse lint`
-- `rainix-sol-artifacts` — `forge build`
+- `forge build` — compile.
+- `forge test` — the test suite.
+- `forge fmt --check` — formatting.
+- `slither .` — static analysis, config in `slither.config.json`.
+- `reuse lint` — REUSE compliance.
+
+CI runs all of those except `forge build`, plus `rainix-sol-single-contract`,
+which this repo's pinned rainix does not provide.
+
+`rainix-sol-artifacts` is on `PATH` too and is not a build. It runs
+`forge selectors up --all` against the public selector registry, then
+`forge script script/Deploy.sol` against `$ETH_RPC_URL` signed with
+`DEPLOYMENT_KEY`, broadcasting when `DEPLOY_BROADCAST` is set. There is no
+`script/` directory here. Do not run it.
 
 Use the nix-pinned `forge` for all development to keep versions consistent.
 
@@ -78,7 +88,7 @@ This repo is [REUSE 3.2](https://reuse.software/spec-3.2/) compliant. Verify
 locally:
 
 ```sh
-nix develop -c rainix-sol-legal
+nix develop -c reuse lint
 ```
 
 ## Contributions


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.solmem/issues/78

Two changes, both in `README.md`.

### The Develop shell task list goes, with no replacement

It listed four tasks:

| Listed as | Reality |
| --- | --- |
| `rainix-sol-test` — `forge test` | not a command — `.github/workflows/rainix-sol-test.yaml` in rainix |
| `rainix-sol-static` — slither | not a command — `.github/workflows/rainix-sol-static.yaml` |
| `rainix-sol-legal` — `reuse lint` | not a command — `.github/workflows/rainix-sol-legal.yaml` |
| `rainix-sol-artifacts` — `forge build` | a real command, but a deploy, not a build |

The first three are CI workflow filenames. They are reached through `rainix-sol.yaml`, which is what this repo's `.github/workflows/rainix.yaml` calls; none of them is a task in rainix's `flake.nix`, so none is on `PATH` in the pinned `sol-shell`. The list read as a map of the dev shell and never was one, and enumerating `forge` subcommands is not this README's job — so nothing replaces it. Develop now ends where it already did: "Use the nix-pinned `forge` for all development to keep versions consistent."

### The `rainix-sol-artifacts` hazard goes to rainix, not into this README

It is real — `forge selectors up --all` against the public selector registry, then a `DEPLOYMENT_KEY`-signed `forge script script/Deploy.sol` that broadcasts under `DEPLOY_BROADCAST`. But the name is defined in rainix, and a warning in one consumer's README does not reach the others. Filed as rainlanguage/rainix#325, asking for a name that says deploy or a guard on the registry write and the RPC.

### `nix develop -c rainix-sol-legal` → `nix develop -c reuse lint`

The README's one falsifiable licensing claim now has a command that runs. `reuse` is in the shell under its own name.

## QA

- **Discriminating tests:** n/a — docs-only diff. Binding README prose with a test is ruled out org-wide; the equivalent PR was stripped from this repo today (`c2a7cf5`, "Drop the README tests, keep the statement").
- **Mutations applied:** n/a — no code or test changed, so there is no behaviour to mutate.
- **Oracle:** rainix's source, not the README.
  - `flake.nix` at rainix `main` — the only sol tasks defined are `rainix-sol-artifacts` (:249) and `rainix-sol-single-contract` (:332). There is no `rainix-sol-test`/`-static`/`-legal` package for the shell to put on `PATH`.
  - `.github/workflows/` at rainix `main` — `rainix-sol-test.yaml`, `rainix-sol-static.yaml` and `rainix-sol-legal.yaml` exist, and `rainix-sol.yaml:27-31` calls all three. That is where those three names live.
  - `flake.nix:249-323` for what `rainix-sol-artifacts` runs, quoted with line refs in rainlanguage/rainix#325.
  - The `nix develop -c command -v` evidence that the three are absent from the pinned shell is #78's and was not re-run for this push. The deletion does not rest on it: a name that is not a package in the flake cannot be a task in the flake's shell.
- **What changed since the first push:** `e440eb3` swapped the four wrong names for five right ones and added a paragraph describing the `rainix-sol-artifacts` deploy. Ruled the wrong shape — a curated command list is a thing to keep correct forever, and the artifacts warning belongs upstream. `05c9363` removes all of it. The net diff against `main` is now a 7-line deletion plus the one-line REUSE fix.
- **Category check:** the issue asks for (a) the three non-existent tasks, (b) `rainix-sol-artifacts` mis-described as `forge build`, (c) the unrunnable `nix develop -c rainix-sol-legal`, (d) a README-path CI gate in rainix. (a) and (b) are fixed by deletion — no claim, no wrong claim, and nothing left to rot. (b)'s underlying hazard is re-filed at rainlanguage/rainix#325 rather than dropped. (c) is fixed in place. (d) is not done here: it is rainix's file, and it is a doc-binding test of the kind `c2a7cf5` already ruled out.
