### PR TITLE
Document the safety contract, and stop claiming the allocator is bypassed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # rain.solmem
 
 Solidity memory libraries — pointer arithmetic, byte-level copying, and dynamic
-arrays/matrices that don't go through Solidity's safety-checked allocator.
+arrays/matrices built in raw assembly rather than through Solidity's
+bounds-checked, zeroing array handling. Allocating functions still read and
+update the free memory pointer at `0x40`; the safety checks are skipped, the
+allocator is not.
 
 ## Libraries
 
@@ -16,8 +19,30 @@ arrays/matrices that don't go through Solidity's safety-checked allocator.
 | `LibBytes32Matrix` | `bytes32[][]` operations.                                                 |
 | `LibStackSentinel` | Sentinel-terminated stack walks for unknown-length data.                  |
 
-These libraries assume the caller knows what they're doing with memory. Out-of-
-bounds access, double-frees, and aliasing are the caller's responsibility.
+## Safety contract
+
+These libraries assume the caller knows what they're doing with memory. There is
+no `free` in EVM memory, so the hazards are out-of-bounds reads and writes,
+silent pointer wraparound, and aliasing.
+
+- A `Pointer` is a bare `uint256`. `LibPointer` arithmetic wraps silently and is
+  checked against neither `0x40` nor the length prefix of the structure the
+  pointer came from.
+- `unsafe*` functions perform no bounds checks. The caller MUST establish, at
+  its own call sites, that every read is in bounds and every write lands in
+  memory the caller owns.
+- Functions that allocate read and update `0x40` themselves, so they MUST NOT be
+  interleaved with hand-written assembly that caches `0x40` across the call.
+- `unsafeExtend` MAY mutate its base argument in place and MAY return a pointer
+  to it. Use the returned array only.
+- Overlap between arguments is the caller's problem. Every array or `bytes`
+  argument MUST be a valid Solidity memory structure that owns the region its
+  own length word describes.
+- Every assembly block in `src/` is annotated `("memory-safe")`. That annotation
+  is an assertion to the compiler, not a guarantee to the caller: it holds for
+  these functions only while the obligations above hold. The functions are
+  `internal` and inline, so the assertion lands inside the consumer's own
+  compilation unit.
 
 ## Requirements
 


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.solmem/issues/79

## Verified against main first

Issue 79 was filed against an older tree. Every claim re-checked against `9a238f4`:

| Claim in the issue | State on main |
| --- | --- |
| `README.md:3-4` says the arrays/matrices "don't go through Solidity's safety-checked allocator" | **Still there, still false.** `grep -rn 'mstore(0x40' src/` hits 33 sites: `arrayFrom` (all 10 overloads across both array libs), `matrixFrom` (all 3, both matrix libs), `flatten` (both), `unsafeExtend` (both), `LibStackSentinel.consumeSentinelTuples`. Each pairs with an `mload(0x40)`. |
| `README.md:20-21` names "double-frees" as a hazard | **Still there.** Nothing in `src/` frees or deallocates. |
| The meaning of the `("memory-safe")` annotation is undocumented | **True.** `grep -rn 'memory-safe' README.md` -> no match. |
| Every assembly block in `src/` is annotated | **True.** 70 `assembly` blocks, 70 annotated `("memory-safe")`, 0 bare. |
| Per-function obligation missing on `LibPointer.unsafeWriteWord`, `LibPointer.unsafeAsBytes`, `LibMemCpy.unsafeCopyBytesTo`, `LibMemCpy.unsafeCopyWordsTo` | **Already documented.** All four carry a "the caller MUST ensure ..." clause in NatSpec on main. |
| Same for `LibStackPointer.unsafePush` / `unsafeList` | **Stale.** `LibStackPointer` was deleted in `07e18be` (#112). |

Two things the issue's proposed text would get wrong against current main, so
they are not in this diff as written:

- "Aliasing is not detected" is no longer true across the board. #123 landed
  `iszero(eq(base, extend))` in `unsafeExtend`, which detects exactly the
  self-extend alias. The bullet states the precondition instead - each argument
  owns the region its own length word describes - matching the framing landed in
  `38127ba`.
- "`unsafe*` functions read and write memory the compiler does not know about"
  is false for `unsafeAddBytes` / `unsafeAddWord` / `unsafeAddWords` /
  `unsafeSubWord` / `unsafeSubWords`, which touch no memory at all. The bullet
  says "perform no bounds checks".

## What changed

`README.md` only.

- The opening paragraph now says what is actually skipped - bounds checking and
  zeroing - and states that allocating functions read and update `0x40`.
- The two-sentence hazard list becomes a `## Safety contract` section: unchecked
  pointer arithmetic, no bounds checks in `unsafe*`, allocating functions own
  `0x40` across the call, `unsafeExtend` may return its own base, arguments must
  own the region their length word describes, and the `("memory-safe")`
  annotation is an assertion to the compiler that holds only while those
  obligations do.

`README.md` is not in `.soldeerignore`, so this ships inside the soldeer package
rather than only living on GitHub.

The annotation caveat is stated once rather than pasted onto four functions. It
is a property of all 70 assembly blocks in `src/`, not of those four, and those
four already state their own caller obligation.

## QA

- Discriminating tests: n/a - the diff is `README.md` only, zero lines of `src/`
  or `test/`. The only test that could discriminate it would read `README.md`
  and assert its prose, which is what `c2a7cf5` stripped out of #118.
- Mutations applied: n/a - a docs-only diff has no behaviour to mutate.
  `git diff --stat main...HEAD` is `README.md | 31 +++++++++++++++++++++-----`
  and nothing else.
- Oracle: the source tree, not the old README. Each added sentence was checked
  against `src/` before writing it - `grep -rn 'mstore(0x40' src/` -> 33 sites
  across `arrayFrom`, `matrixFrom`, `flatten`, `unsafeExtend`,
  `consumeSentinelTuples` (the allocator claim); `grep -rn 'assembly' src/` ->
  70 blocks, all annotated, none bare (the annotation claim); the `unsafeExtend`
  NatSpec and its `iszero(eq(base, extend))` branch from #123 (the mutate-base
  and overlap claims); `LibPointer`'s five raw `add`/`sub` bodies (the
  unchecked-arithmetic claim).
- Category check: issue asks (A) fix the false allocator claim at
  `README.md:3-4`, (B) replace the "double-frees" hazard sentence with a real
  safety contract, (C) restate the annotation caveat per-function. A and B
  covered. C is Refs-only: two of its six named functions
  (`LibStackPointer.unsafePush`, `unsafeList`) no longer exist, deleted in
  `07e18be`, and the other four already carry their caller obligation in NatSpec
  on main. The caveat is a property of all 70 assembly blocks, so it is stated
  once in the safety contract instead of on four of seventy.

`nix develop -c forge fmt --check` passes. `nix develop -c forge test` on this
branch: 349 tests passed, 0 failed, 0 skipped across 33 suites - unchanged from
main, as a README edit cannot move it.
