### PR TITLE
Pin itemCount literal counts, aliased sub arrays and flatten source immutability

### DIFF
--- a/test/src/lib/LibBytes32Matrix.flatten.t.sol
+++ b/test/src/lib/LibBytes32Matrix.flatten.t.sol
@@ -3,10 +3,13 @@
 pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {LibBytes32Array} from "src/lib/LibBytes32Array.sol";
 import {LibBytes32Matrix} from "src/lib/LibBytes32Matrix.sol";
+import {LibPointer, Pointer} from "src/lib/LibPointer.sol";
 import {LibBytes32MatrixSlow} from "test/lib/LibBytes32MatrixSlow.sol";
 
 contract LibBytes32MatrixFlattenTest is Test {
+    using LibBytes32Array for bytes32[];
     using LibBytes32Matrix for bytes32[][];
     using LibBytes32MatrixSlow for bytes32[][];
 
@@ -278,5 +281,66 @@ contract LibBytes32MatrixFlattenTest is Test {
     /// forge-config: default.fuzz.runs = 100
     function testFlattenReference(bytes32[][] memory matrix) external pure {
         checkFlatten(matrix, LibBytes32MatrixSlow.flattenSlow(matrix));
+    }
+
+    /// `matrixFrom` stores the pointers it is handed, so one sub array can
+    /// appear more than once. Every appearance is copied out in order and the
+    /// shared source is left intact. ABI decoding allocates a fresh sub array
+    /// per element, so `testFlattenReference` never builds this shape, and this
+    /// is the only case that flattens a matrix built by `matrixFrom`.
+    function testFlattenAliasedInnerArrays() external pure {
+        bytes32[] memory a = LibBytes32Array.arrayFrom(bytes32(uint256(0x11)), bytes32(uint256(0x22)));
+        bytes32[][] memory matrix = LibBytes32Matrix.matrixFrom(a, a, a);
+
+        bytes32[] memory flattened = matrix.flatten();
+        // Read the free memory pointer BEFORE any assertion, because assertions
+        // allocate and would move it.
+        uint256 fmpAfter = uint256(Pointer.unwrap(LibPointer.allocatedMemoryPointer()));
+        uint256 endOfFlattened = uint256(Pointer.unwrap(flattened.endPointer()));
+
+        assertEq(flattened.length, 6, "length");
+        for (uint256 i = 0; i < 3; i++) {
+            assertEq(flattened[i * 2], bytes32(uint256(0x11)), "even");
+            assertEq(flattened[(i * 2) + 1], bytes32(uint256(0x22)), "odd");
+        }
+        assertEq(fmpAfter, endOfFlattened, "fmp");
+        assertEq(a.length, 2, "source length");
+        assertEq(a[0], bytes32(uint256(0x11)), "source 0");
+        assertEq(a[1], bytes32(uint256(0x22)), "source 1");
+    }
+
+    /// `flatten` writes only within its own allocation, so the matrix and its
+    /// sub arrays read back unchanged. `checkFlatten` cannot see this: at every
+    /// call site `flattenSlow` captures the expected array from the pristine
+    /// matrix before `flatten` runs.
+    function testFlattenLeavesSourceUnmodified() external pure {
+        bytes32[] memory a = LibBytes32Array.arrayFrom(bytes32(uint256(0x11)), bytes32(uint256(0x22)));
+        bytes32[] memory b = LibBytes32Array.arrayFrom(bytes32(uint256(0x33)));
+        bytes32[][] memory matrix = LibBytes32Matrix.matrixFrom(a, b);
+
+        matrix.flatten();
+
+        assertEq(matrix.length, 2, "outer length");
+        assertEq(matrix[0].length, 2, "sub 0 length");
+        assertEq(matrix[0][0], bytes32(uint256(0x11)), "sub 0 item 0");
+        assertEq(matrix[0][1], bytes32(uint256(0x22)), "sub 0 item 1");
+        assertEq(matrix[1].length, 1, "sub 1 length");
+        assertEq(matrix[1][0], bytes32(uint256(0x33)), "sub 1 item 0");
+    }
+
+    /// `testFlattenLeavesSourceUnmodified` over the shapes the fuzzer reaches.
+    /// forge-config: default.fuzz.runs = 100
+    function testFlattenLeavesSourceUnmodifiedFuzz(bytes32[][] memory matrix) external pure {
+        bytes32[][] memory snapshot = new bytes32[][](matrix.length);
+        for (uint256 i = 0; i < matrix.length; i++) {
+            snapshot[i] = new bytes32[](matrix[i].length);
+            for (uint256 j = 0; j < matrix[i].length; j++) {
+                snapshot[i][j] = matrix[i][j];
+            }
+        }
+
+        matrix.flatten();
+
+        assertTrue(LibBytes32MatrixSlow.compareMatrices(matrix, snapshot, snapshot.length), "source unmodified");
     }
 }

--- a/test/src/lib/LibBytes32Matrix.flatten.t.sol
+++ b/test/src/lib/LibBytes32Matrix.flatten.t.sol
@@ -310,9 +310,9 @@ contract LibBytes32MatrixFlattenTest is Test {
     }
 
     /// `flatten` writes only within its own allocation, so the matrix and its
-    /// sub arrays read back unchanged. `checkFlatten` cannot see this: at every
-    /// call site `flattenSlow` captures the expected array from the pristine
-    /// matrix before `flatten` runs.
+    /// sub arrays read back unchanged. No case above sees this: `checkFlatten`
+    /// only reads the result, and `testFlattenReference` captures its expected
+    /// array from the pristine matrix before `flatten` runs.
     function testFlattenLeavesSourceUnmodified() external pure {
         bytes32[] memory a = LibBytes32Array.arrayFrom(bytes32(uint256(0x11)), bytes32(uint256(0x22)));
         bytes32[] memory b = LibBytes32Array.arrayFrom(bytes32(uint256(0x33)));

--- a/test/src/lib/LibBytes32Matrix.itemCount.t.sol
+++ b/test/src/lib/LibBytes32Matrix.itemCount.t.sol
@@ -4,6 +4,7 @@ pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibBytes32Matrix} from "src/lib/LibBytes32Matrix.sol";
+import {LibBytes32Array} from "src/lib/LibBytes32Array.sol";
 import {LibPointer, Pointer} from "src/lib/LibPointer.sol";
 import {LibBytes32MatrixSlow} from "test/lib/LibBytes32MatrixSlow.sol";
 
@@ -22,5 +23,62 @@ contract LibBytes32MatrixItemCountTest is Test {
         assertEq(Pointer.unwrap(allocatedBefore), Pointer.unwrap(allocatedAfter), "itemCount allocated");
 
         assertEq(count, matrix.itemCountSlow());
+    }
+
+    /// An empty matrix has no sub arrays to sum, so the count is zero.
+    function testItemCountEmptyMatrix() external pure {
+        assertEq(LibBytes32Matrix.itemCount(new bytes32[][](0)), 0, "empty matrix");
+    }
+
+    /// Sub arrays that are all empty sum to zero, not to the outer length.
+    function testItemCountAllInnerEmpty() external pure {
+        bytes32[][] memory matrix = new bytes32[][](3);
+        matrix[0] = new bytes32[](0);
+        matrix[1] = new bytes32[](0);
+        matrix[2] = new bytes32[](0);
+        assertEq(matrix.itemCount(), 0, "all inner empty");
+    }
+
+    /// A lone sub array contributes its own length.
+    function testItemCountSingleInner() external pure {
+        assertEq(
+            LibBytes32Matrix.matrixFrom(
+                    LibBytes32Array.arrayFrom(bytes32(uint256(0x11)), bytes32(uint256(0x22)), bytes32(uint256(0x33)))
+                ).itemCount(),
+            3,
+            "single inner"
+        );
+    }
+
+    /// Empty sub arrays between non empty ones contribute nothing.
+    function testItemCountEmptyInterleaved() external pure {
+        bytes32[][] memory matrix = new bytes32[][](5);
+        matrix[0] = new bytes32[](0);
+        matrix[1] = LibBytes32Array.arrayFrom(bytes32(uint256(0x11)), bytes32(uint256(0x22)));
+        matrix[2] = new bytes32[](0);
+        matrix[3] = LibBytes32Array.arrayFrom(bytes32(uint256(0x33)));
+        matrix[4] = new bytes32[](0);
+        assertEq(matrix.itemCount(), 3, "empty interleaved");
+    }
+
+    /// The count is the SUM over sub arrays: not the outer length 3, not the
+    /// first sub array length 1, not the longest sub array length 4.
+    function testItemCountSumsAcrossInnerArrays() external pure {
+        bytes32[][] memory matrix = new bytes32[][](3);
+        matrix[0] = LibBytes32Array.arrayFrom(bytes32(uint256(0x11)));
+        matrix[1] = LibBytes32Array.arrayFrom(
+            bytes32(uint256(0x22)), bytes32(uint256(0x33)), bytes32(uint256(0x44)), bytes32(uint256(0x55))
+        );
+        matrix[2] = LibBytes32Array.arrayFrom(bytes32(uint256(0x66)), bytes32(uint256(0x77)));
+        assertEq(matrix.itemCount(), 7, "sum across sub arrays");
+    }
+
+    /// `matrixFrom` stores the pointers it is handed, so one sub array can
+    /// appear more than once and each appearance is counted. ABI decoding
+    /// allocates a fresh sub array per element, so the fuzz above never builds
+    /// this shape.
+    function testItemCountAliasedInnerArrays() external pure {
+        bytes32[] memory a = LibBytes32Array.arrayFrom(bytes32(uint256(0x11)), bytes32(uint256(0x22)));
+        assertEq(LibBytes32Matrix.matrixFrom(a, a, a).itemCount(), 6, "aliased sub arrays");
     }
 }

--- a/test/src/lib/LibUint256Matrix.flatten.t.sol
+++ b/test/src/lib/LibUint256Matrix.flatten.t.sol
@@ -310,9 +310,9 @@ contract LibUint256MatrixFlattenTest is Test {
     }
 
     /// `flatten` writes only within its own allocation, so the matrix and its
-    /// sub arrays read back unchanged. `checkFlatten` cannot see this: at every
-    /// call site `flattenSlow` captures the expected array from the pristine
-    /// matrix before `flatten` runs.
+    /// sub arrays read back unchanged. No case above sees this: `checkFlatten`
+    /// only reads the result, and `testFlattenReference` captures its expected
+    /// array from the pristine matrix before `flatten` runs.
     function testFlattenLeavesSourceUnmodified() external pure {
         uint256[] memory a = LibUint256Array.arrayFrom(0x11, 0x22);
         uint256[] memory b = LibUint256Array.arrayFrom(0x33);

--- a/test/src/lib/LibUint256Matrix.flatten.t.sol
+++ b/test/src/lib/LibUint256Matrix.flatten.t.sol
@@ -3,10 +3,13 @@
 pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {LibUint256Array} from "src/lib/LibUint256Array.sol";
 import {LibUint256Matrix} from "src/lib/LibUint256Matrix.sol";
+import {LibPointer, Pointer} from "src/lib/LibPointer.sol";
 import {LibUint256MatrixSlow} from "test/lib/LibUint256MatrixSlow.sol";
 
 contract LibUint256MatrixFlattenTest is Test {
+    using LibUint256Array for uint256[];
     using LibUint256Matrix for uint256[][];
     using LibUint256MatrixSlow for uint256[][];
 
@@ -278,5 +281,66 @@ contract LibUint256MatrixFlattenTest is Test {
     /// forge-config: default.fuzz.runs = 100
     function testFlattenReference(uint256[][] memory matrix) external pure {
         checkFlatten(matrix, LibUint256MatrixSlow.flattenSlow(matrix));
+    }
+
+    /// `matrixFrom` stores the pointers it is handed, so one sub array can
+    /// appear more than once. Every appearance is copied out in order and the
+    /// shared source is left intact. ABI decoding allocates a fresh sub array
+    /// per element, so `testFlattenReference` never builds this shape, and this
+    /// is the only case that flattens a matrix built by `matrixFrom`.
+    function testFlattenAliasedInnerArrays() external pure {
+        uint256[] memory a = LibUint256Array.arrayFrom(0x11, 0x22);
+        uint256[][] memory matrix = LibUint256Matrix.matrixFrom(a, a, a);
+
+        uint256[] memory flattened = matrix.flatten();
+        // Read the free memory pointer BEFORE any assertion, because assertions
+        // allocate and would move it.
+        uint256 fmpAfter = uint256(Pointer.unwrap(LibPointer.allocatedMemoryPointer()));
+        uint256 endOfFlattened = uint256(Pointer.unwrap(flattened.endPointer()));
+
+        assertEq(flattened.length, 6, "length");
+        for (uint256 i = 0; i < 3; i++) {
+            assertEq(flattened[i * 2], 0x11, "even");
+            assertEq(flattened[(i * 2) + 1], 0x22, "odd");
+        }
+        assertEq(fmpAfter, endOfFlattened, "fmp");
+        assertEq(a.length, 2, "source length");
+        assertEq(a[0], 0x11, "source 0");
+        assertEq(a[1], 0x22, "source 1");
+    }
+
+    /// `flatten` writes only within its own allocation, so the matrix and its
+    /// sub arrays read back unchanged. `checkFlatten` cannot see this: at every
+    /// call site `flattenSlow` captures the expected array from the pristine
+    /// matrix before `flatten` runs.
+    function testFlattenLeavesSourceUnmodified() external pure {
+        uint256[] memory a = LibUint256Array.arrayFrom(0x11, 0x22);
+        uint256[] memory b = LibUint256Array.arrayFrom(0x33);
+        uint256[][] memory matrix = LibUint256Matrix.matrixFrom(a, b);
+
+        matrix.flatten();
+
+        assertEq(matrix.length, 2, "outer length");
+        assertEq(matrix[0].length, 2, "sub 0 length");
+        assertEq(matrix[0][0], 0x11, "sub 0 item 0");
+        assertEq(matrix[0][1], 0x22, "sub 0 item 1");
+        assertEq(matrix[1].length, 1, "sub 1 length");
+        assertEq(matrix[1][0], 0x33, "sub 1 item 0");
+    }
+
+    /// `testFlattenLeavesSourceUnmodified` over the shapes the fuzzer reaches.
+    /// forge-config: default.fuzz.runs = 100
+    function testFlattenLeavesSourceUnmodifiedFuzz(uint256[][] memory matrix) external pure {
+        uint256[][] memory snapshot = new uint256[][](matrix.length);
+        for (uint256 i = 0; i < matrix.length; i++) {
+            snapshot[i] = new uint256[](matrix[i].length);
+            for (uint256 j = 0; j < matrix[i].length; j++) {
+                snapshot[i][j] = matrix[i][j];
+            }
+        }
+
+        matrix.flatten();
+
+        assertTrue(LibUint256MatrixSlow.compareMatrices(matrix, snapshot, snapshot.length), "source unmodified");
     }
 }

--- a/test/src/lib/LibUint256Matrix.itemCount.t.sol
+++ b/test/src/lib/LibUint256Matrix.itemCount.t.sol
@@ -4,6 +4,7 @@ pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibUint256Matrix} from "src/lib/LibUint256Matrix.sol";
+import {LibUint256Array} from "src/lib/LibUint256Array.sol";
 import {LibPointer, Pointer} from "src/lib/LibPointer.sol";
 import {LibUint256MatrixSlow} from "test/lib/LibUint256MatrixSlow.sol";
 
@@ -22,5 +23,56 @@ contract LibUint256MatrixItemCountTest is Test {
         assertEq(Pointer.unwrap(allocatedBefore), Pointer.unwrap(allocatedAfter), "itemCount allocated");
 
         assertEq(count, matrix.itemCountSlow());
+    }
+
+    /// An empty matrix has no sub arrays to sum, so the count is zero.
+    function testItemCountEmptyMatrix() external pure {
+        assertEq(LibUint256Matrix.itemCount(new uint256[][](0)), 0, "empty matrix");
+    }
+
+    /// Sub arrays that are all empty sum to zero, not to the outer length.
+    function testItemCountAllInnerEmpty() external pure {
+        uint256[][] memory matrix = new uint256[][](3);
+        matrix[0] = new uint256[](0);
+        matrix[1] = new uint256[](0);
+        matrix[2] = new uint256[](0);
+        assertEq(matrix.itemCount(), 0, "all inner empty");
+    }
+
+    /// A lone sub array contributes its own length.
+    function testItemCountSingleInner() external pure {
+        assertEq(
+            LibUint256Matrix.matrixFrom(LibUint256Array.arrayFrom(0x11, 0x22, 0x33)).itemCount(), 3, "single inner"
+        );
+    }
+
+    /// Empty sub arrays between non empty ones contribute nothing.
+    function testItemCountEmptyInterleaved() external pure {
+        uint256[][] memory matrix = new uint256[][](5);
+        matrix[0] = new uint256[](0);
+        matrix[1] = LibUint256Array.arrayFrom(0x11, 0x22);
+        matrix[2] = new uint256[](0);
+        matrix[3] = LibUint256Array.arrayFrom(0x33);
+        matrix[4] = new uint256[](0);
+        assertEq(matrix.itemCount(), 3, "empty interleaved");
+    }
+
+    /// The count is the SUM over sub arrays: not the outer length 3, not the
+    /// first sub array length 1, not the longest sub array length 4.
+    function testItemCountSumsAcrossInnerArrays() external pure {
+        uint256[][] memory matrix = new uint256[][](3);
+        matrix[0] = LibUint256Array.arrayFrom(0x11);
+        matrix[1] = LibUint256Array.arrayFrom(0x22, 0x33, 0x44, 0x55);
+        matrix[2] = LibUint256Array.arrayFrom(0x66, 0x77);
+        assertEq(matrix.itemCount(), 7, "sum across sub arrays");
+    }
+
+    /// `matrixFrom` stores the pointers it is handed, so one sub array can
+    /// appear more than once and each appearance is counted. ABI decoding
+    /// allocates a fresh sub array per element, so the fuzz above never builds
+    /// this shape.
+    function testItemCountAliasedInnerArrays() external pure {
+        uint256[] memory a = LibUint256Array.arrayFrom(0x11, 0x22);
+        assertEq(LibUint256Matrix.matrixFrom(a, a, a).itemCount(), 6, "aliased sub arrays");
     }
 }


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.solmem/issues/72

## Verified against main first

All three gaps are still real on `main` at `9a238f4`.

- `test/src/lib/LibUint256Matrix.itemCount.t.sol` and its `bytes32` twin each hold exactly one test, `testItemCountReference`: a fuzz against `itemCountSlow` plus a free memory pointer assertion. No literal expected count anywhere.
- No test builds a matrix whose elements alias one sub array. `matrixFrom` has 16 call sites in `test/` (`matrixFrom.t.sol` and `endPointer.t.sol`, both types) and every one passes distinct arrays. `flatten` is never applied to a `matrixFrom` result at all; every `flatten` input is `new uint256[][](n)` or an ABI decoded fuzz input, and ABI decoding materialises a fresh sub array per element so the fuzz cannot produce an alias.
- Nothing asserts `flatten` leaves its source alone. `checkFlatten` only reads the result, and `testFlattenReference` passes `flattenSlow(matrix)`, which is evaluated before `flatten` runs.

## Changed

Tests only, no `src` change.

`LibUint256Matrix.itemCount.t.sol` and `LibBytes32Matrix.itemCount.t.sol`

- `testItemCountEmptyMatrix`, `testItemCountAllInnerEmpty`, `testItemCountSingleInner`, `testItemCountEmptyInterleaved` — literal counts for the shapes the fuzz was the only cover for.
- `testItemCountSumsAcrossInnerArrays` — outer length 3, first sub array length 1, longest sub array length 4, expected 7, so the sum is distinguished from all three.
- `testItemCountAliasedInnerArrays` — `matrixFrom(a, a, a).itemCount()` is 6.

`LibUint256Matrix.flatten.t.sol` and `LibBytes32Matrix.flatten.t.sol`

- `testFlattenAliasedInnerArrays` — `matrixFrom(a, a, a)` flattens to its 6 items in order, the free memory pointer lands exactly on the end of the result, and `a` reads back intact. Also the only case that flattens a `matrixFrom` built matrix.
- `testFlattenLeavesSourceUnmodified` — literal source contents after `flatten`.
- `testFlattenLeavesSourceUnmodifiedFuzz` — the same property over fuzzed shapes, against a snapshot taken before the call, compared with the existing `compareMatrices` helper.

`nix develop -c forge test`: 367 tests passed, 0 failed, 33 suites. On `main` the same command runs 349.

## QA

- Discriminating tests: `testItemCountAliasedInnerArrays`, `testFlattenAliasedInnerArrays`, `testFlattenLeavesSourceUnmodified`, `testFlattenLeavesSourceUnmodifiedFuzz` (both types) — each is the only thing that fails under a mutant `main`'s suite passes clean, verified by running the whole suite twice per mutant, once with `test/` at this branch and once with `test/` checked out from `main`. The six `itemCount` anchors are not discriminating against `main`'s suite: mutating the sum is already caught by `testItemCountReference` and by the concrete `flatten` cases, so what they add is a literal expected value that does not depend on the fuzz generator or seed, shown by M1 below.
- Mutations applied: both `src/lib/LibUint256Matrix.sol` and `src/lib/LibBytes32Matrix.sol` were mutated together for every row, so each kill count is two tests, one per type. Suite totals are quoted to show the tests ran.

| # | Mutation | This branch | `main`'s tests |
| --- | --- | --- | --- |
| M1 | `itemCount`: `count := add(count, subCount)` → `count := add(count, 1)` (count sub arrays, not items) | KILLED, 52 failed / 367 ran, incl. all 6 new anchors: `testItemCountEmptyMatrix` is the only one that survives, correctly, an empty matrix counts 0 either way | KILLED, 36 failed / 349 ran |
| M2 | `itemCount`: `if eq(mload(cursor), mload(sub(cursor, 0x20))) { subCount := 0 }` before the accumulate (skip a repeated sub array pointer) | KILLED, 4 failed / 367 ran: `testItemCountAliasedInnerArrays` (2 != 6), `testFlattenAliasedInnerArrays` (length 2 != 6) | SURVIVED, 0 failed / 349 ran |
| M3 | `flatten`: after the copy loop, `mstore(add(s0, 0x20), 0)` on the first sub array (corrupt the source once the result is already built) | KILLED, 6 failed / 367 ran: `testFlattenLeavesSourceUnmodified` (sub 0 item 0: 0 != 17), `testFlattenLeavesSourceUnmodifiedFuzz`, `testFlattenAliasedInnerArrays` (source 0: 0 != 17) | SURVIVED, 0 failed / 349 ran |
| M4 | `flatten`: `if eq(mload(cursor), mload(sub(cursor, 0x20))) { size := 0 }` in the copy loop (emit a repeated sub array once) | KILLED, 2 failed / 367 ran: `testFlattenAliasedInnerArrays` | SURVIVED, 0 failed / 349 ran |

- Oracle: literal expected values written from the definition of each function, not read back from the implementation. `itemCount` counts are hand summed; `testItemCountSumsAcrossInnerArrays` picks 3 sub arrays of lengths 1, 4, 2 so the expected 7 differs from the outer length, the first length and the max. `flatten`'s aliased expectation is the 6 item repetition of a 2 item array. The source immutability cases compare against literals, and the fuzz case against a copy taken before the call. The existing `itemCountSlow` / `flattenSlow` differential oracles are untouched.
- Category check: issue asks for (a) deterministic `itemCount` anchors, (b) aliased inner array coverage for both `itemCount` and `flatten`, (c) an assertion that `flatten` leaves its source unmodified, all mirrored into the `bytes32` twin. Covered a, b, c for both types.
