### PR TITLE
Converge the uint256 and bytes32 array suites

### DIFF
--- a/test/src/lib/LibArray.selfExtend.t.sol
+++ b/test/src/lib/LibArray.selfExtend.t.sol
@@ -214,17 +214,20 @@ contract LibArraySelfExtendTest is Test {
     }
 
     function testSelfExtendBytes32DoublesTheContents() external pure {
-        bytes32[] memory a = new bytes32[](2);
-        a[0] = bytes32(uint256(0xAA));
-        a[1] = bytes32(uint256(0xBB));
+        bytes32[] memory a = new bytes32[](3);
+        a[0] = bytes32(uint256(0x11));
+        a[1] = bytes32(uint256(0x22));
+        a[2] = bytes32(uint256(0x33));
 
         bytes32[] memory extended = a.unsafeExtend(a);
 
-        assertEq(extended.length, 4);
-        assertEq(extended[0], bytes32(uint256(0xAA)));
-        assertEq(extended[1], bytes32(uint256(0xBB)));
-        assertEq(extended[2], bytes32(uint256(0xAA)));
-        assertEq(extended[3], bytes32(uint256(0xBB)));
+        assertEq(extended.length, 6);
+        assertEq(extended[0], bytes32(uint256(0x11)));
+        assertEq(extended[1], bytes32(uint256(0x22)));
+        assertEq(extended[2], bytes32(uint256(0x33)));
+        assertEq(extended[3], bytes32(uint256(0x11)));
+        assertEq(extended[4], bytes32(uint256(0x22)));
+        assertEq(extended[5], bytes32(uint256(0x33)));
     }
 
     function testSelfExtendBytes32AllocatesExactly() external pure {

--- a/test/src/lib/LibBytes32Array.allocation.t.sol
+++ b/test/src/lib/LibBytes32Array.allocation.t.sol
@@ -16,34 +16,18 @@ import {LibPointer} from "src/lib/LibPointer.sol";
 /// Every one of these tests must read the free memory pointer IMMEDIATELY after
 /// the call under test. Assertions allocate, so any assertion made first moves
 /// the free memory pointer and destroys the measurement.
+///
+/// The poison tests keep the whole measurement in two assembly blocks flush
+/// against the call under test: one writes the sentinels and snapshots the
+/// pointer, the call runs, the next snapshots the pointer again and copies the
+/// sentinels down into an array allocated beforehand. Memory at or above the
+/// free memory pointer belongs to whichever assembly block is running, so any
+/// call on that path is entitled to reuse the poisoned region.
 contract LibBytes32ArrayAllocationTest is Test {
     using LibBytes32Array for bytes32[];
 
     /// Number of words of free memory poisoned above the free memory pointer.
     uint256 internal constant POISON_WORDS = 8;
-
-    /// Poison `POISON_WORDS` words of FREE memory starting at the free memory
-    /// pointer with per-word recognisable sentinels. Returns the free memory
-    /// pointer as it stood before the call under test.
-    function _poisonFreeMemory() internal pure returns (uint256 fmpBefore) {
-        assembly ("memory-safe") {
-            fmpBefore := mload(0x40)
-            for { let i := 0 } lt(i, 8) { i := add(i, 1) } {
-                mstore(add(fmpBefore, mul(i, 0x20)), add(0xF00D0000, i))
-            }
-        }
-    }
-
-    /// Copy the poisoned region into `captured`, which the caller allocated
-    /// BEFORE poisoning so that it sits below the poisoned region and is itself
-    /// never disturbed. Copying must happen before any assertion runs.
-    function _capture(bytes32[POISON_WORDS] memory captured, uint256 fmpBefore) internal pure {
-        assembly ("memory-safe") {
-            for { let i := 0 } lt(i, 8) { i := add(i, 1) } {
-                mstore(add(captured, mul(i, 0x20)), mload(add(fmpBefore, mul(i, 0x20))))
-            }
-        }
-    }
 
     /// Every poisoned word that lies at or above the FINAL free memory pointer
     /// is still free memory and must therefore be untouched.
@@ -124,13 +108,24 @@ contract LibBytes32ArrayAllocationTest is Test {
         base[0] = bytes32(uint256(0x11));
         base[1] = bytes32(uint256(0x22));
 
-        uint256 fmpBefore = _poisonFreeMemory();
+        // Poison, then the call under test, then snapshot and capture. The two
+        // assembly blocks sit flush against the call so the only boundary the
+        // poison crosses is the call being measured.
+        uint256 fmpBefore;
+        assembly ("memory-safe") {
+            fmpBefore := mload(0x40)
+            for { let i := 0 } lt(i, POISON_WORDS) { i := add(i, 1) } {
+                mstore(add(fmpBefore, mul(i, 0x20)), add(0xF00D0000, i))
+            }
+        }
         bytes32[] memory extended = LibBytes32Array.unsafeExtend(base, extend);
         uint256 fmpAfter;
         assembly ("memory-safe") {
             fmpAfter := mload(0x40)
+            for { let i := 0 } lt(i, POISON_WORDS) { i := add(i, 1) } {
+                mstore(add(captured, mul(i, 0x20)), mload(add(fmpBefore, mul(i, 0x20))))
+            }
         }
-        _capture(captured, fmpBefore);
 
         assertEq(extended.length, 3, "length");
         assertEq(extended[2], bytes32(uint256(0x44)));
@@ -149,13 +144,24 @@ contract LibBytes32ArrayAllocationTest is Test {
         // Allocated after `base`, forcing the allocate-and-copy branch.
         bytes32[] memory extend = new bytes32[](0);
 
-        uint256 fmpBefore = _poisonFreeMemory();
+        // Poison, then the call under test, then snapshot and capture. The two
+        // assembly blocks sit flush against the call so the only boundary the
+        // poison crosses is the call being measured.
+        uint256 fmpBefore;
+        assembly ("memory-safe") {
+            fmpBefore := mload(0x40)
+            for { let i := 0 } lt(i, POISON_WORDS) { i := add(i, 1) } {
+                mstore(add(fmpBefore, mul(i, 0x20)), add(0xF00D0000, i))
+            }
+        }
         bytes32[] memory extended = LibBytes32Array.unsafeExtend(base, extend);
         uint256 fmpAfter;
         assembly ("memory-safe") {
             fmpAfter := mload(0x40)
+            for { let i := 0 } lt(i, POISON_WORDS) { i := add(i, 1) } {
+                mstore(add(captured, mul(i, 0x20)), mload(add(fmpBefore, mul(i, 0x20))))
+            }
         }
-        _capture(captured, fmpBefore);
 
         assertEq(extended.length, 2, "length");
         assertEq(extended[0], bytes32(uint256(0x11)));

--- a/test/src/lib/LibUint256Array.allocation.t.sol
+++ b/test/src/lib/LibUint256Array.allocation.t.sol
@@ -17,18 +17,12 @@ import {LibPointer} from "src/lib/LibPointer.sol";
 /// the call under test. Assertions allocate, so any assertion made first moves
 /// the free memory pointer and destroys the measurement.
 ///
-/// The same applies to the poisoned words, only more strictly. Memory at or
-/// above the free memory pointer is temporary memory belonging to whichever
-/// assembly block is currently running, so the language preserves nothing there
-/// from one block to the next. The poison tests therefore keep the whole
-/// measurement inline in exactly two assembly blocks sat flush against the call
-/// under test: one writes the sentinels and snapshots the pointer, the call
-/// runs, the next snapshots the pointer again and copies the sentinels down
-/// into an array allocated before any of it. The only boundary the poison
-/// crosses is the call being measured, which is the measurement itself and so
-/// cannot be removed. Every other boundary can, and is: no helper call sits on
-/// that path, because the compiler would be entitled to reuse the region for it
-/// and be mistaken for the call under test writing past its allocation.
+/// The poison tests keep the whole measurement in two assembly blocks flush
+/// against the call under test: one writes the sentinels and snapshots the
+/// pointer, the call runs, the next snapshots the pointer again and copies the
+/// sentinels down into an array allocated beforehand. Memory at or above the
+/// free memory pointer belongs to whichever assembly block is running, so any
+/// call on that path is entitled to reuse the poisoned region.
 contract LibUint256ArrayAllocationTest is Test {
     using LibUint256Array for uint256[];
 

--- a/test/src/lib/LibUint256Array.truncate.t.sol
+++ b/test/src/lib/LibUint256Array.truncate.t.sol
@@ -59,7 +59,8 @@ contract LibUint256ArrayTruncateTest is Test {
     }
 
     /// `array.length` is the largest ACCEPTED length — the other side of the
-    /// bound — and truncating to it is a no-op that retains every item.
+    /// bound — and truncating to it is a no-op that neither allocates nor
+    /// disturbs any item.
     function testTruncateToOwnLengthAccepted(uint256[] memory a) public pure {
         uint256 length = a.length;
         uint256[] memory b = new uint256[](length);
@@ -67,7 +68,10 @@ contract LibUint256ArrayTruncateTest is Test {
             b[i] = a[i];
         }
 
+        Pointer allocatedBefore = LibPointer.allocatedMemoryPointer();
         LibUint256Array.truncate(a, length);
+        Pointer allocatedAfter = LibPointer.allocatedMemoryPointer();
+        assertEq(Pointer.unwrap(allocatedBefore), Pointer.unwrap(allocatedAfter), "truncate allocated");
 
         assertEq(a.length, length, "length");
         assertEq(a, b);


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.solmem/issues/73

## Verified against main first

Most of #73 had already landed. https://github.com/rainlanguage/rain.solmem/pull/105 (`c75a09d`, 2026-07-29) fixed five of its six enumerated gaps and the issue was never closed.

| #73 gap | State on main `9a238f4` |
| --- | --- |
| 1. No `LibUint256Array.allocation.t.sol` | Fixed — exists, 4 tests |
| 2. No `LibUint256Matrix.allocation.t.sol` | Fixed — exists, 3 tests |
| 3. `truncate` free-memory-pointer assertion missing | Fixed — `LibUint256Array.truncate.t.sol:29-32` |
| 4. `reverse` free-memory-pointer assertion missing | Fixed — `LibUint256Array.reverse.t.sol:22-25` |
| 5. `itemCount` free-memory-pointer assertion missing | Fixed — `LibUint256Matrix.itemCount.t.sol:19-22` |
| 6a. One self-extend canary for bytes32 vs two for uint256 | Fixed by `41513ab` — both halves have 5 tests |
| 6b. bytes32 self-extend doubling uses length 2, uint256 length 3 | Still present |

#73's enumeration is not the property. Normalising `bytes32`→`uint256` over every mirrored pair (14 files, plus `test/lib/*Slow.sol`) and diffing found 6b plus two drifts the issue never listed, one in each direction:

- `testTruncateToOwnLengthAccepted` asserts the free memory pointer is unmoved for bytes32 and not for uint256.
- The bytes32 poison measurement routes through `_poisonFreeMemory()`/`_capture()` helper calls where the uint256 twin keeps both assembly blocks flush against the call under test. The helpers also looped to a hardcoded `8` rather than `POISON_WORDS`, so the constant was decorative on that side.

## Changed

- `LibUint256Array.truncate.t.sol` — free-memory-pointer assertion on `testTruncateToOwnLengthAccepted`.
- `LibBytes32Array.allocation.t.sol` — poison and capture inlined into the two assembly blocks either side of the call; helpers deleted.
- `LibArray.selfExtend.t.sol` — `testSelfExtendBytes32DoublesTheContents` on a length-3 array, matching its uint256 twin.
- Both allocation test headers — the 12-line poison rationale cut to 6 describing what the tests do.

Every mirrored pair now normalises to zero difference. No test added or removed: 349 before, 349 after, all passing.

## Mutation table

Each run is a single named test, and each line quotes forge's own `Ran N tests for <path>:<contract>` so a zero-match filter cannot be mistaken for a survivor. "main" is the test file checked out from `main` against the same mutant.

| Mutation | Test | main | this PR |
| --- | --- | --- | --- |
| `LibUint256Array.truncate`: `mstore(0x40, add(mload(0x40), 0x20))` after `mstore(array, newLength)` | `testTruncateToOwnLengthAccepted` | SURVIVED — `Ran 1 test`, ok, 1 passed | KILLED — `truncate allocated: 11456 != 11488` |
| `LibBytes32Array.unsafeExtend` inline branch: `mstore(outputEnd, 0xDEAD)` | `testExtendInlineDoesNotWritePastFreeMemoryPointer` | KILLED — `wrote past the free memory pointer` | KILLED — `wrote past the free memory pointer: 0x…dead != 0x…f00d0001` |
| `LibBytes32Array.unsafeExtend`: `let newBaseSize := 0x60`, hardcoding a length-2 array's size | `testSelfExtendBytes32DoublesTheContents` | SURVIVED — `Ran 1 test`, ok, 1 passed | KILLED — `EvmError: StackOverflow` |

The middle row is the honest result: the helper-based measurement killed that mutant too. Inlining it removes a hazard — a call on the poison path is entitled to reuse the region above the free memory pointer, which would silently stop the test measuring — not an observed gap.

The unmutated baseline passes all three tests, and the tree was committed before every mutation.

## QA
- Discriminating tests: `testTruncateToOwnLengthAccepted` (uint256) and `testSelfExtendBytes32DoublesTheContents` - each passes on main's version of the file against the mutant this PR's version fails on, verified by `git checkout main -- <test file>` with the mutated source in place and re-running the same single-test filter. `testExtendInlineDoesNotWritePastFreeMemoryPointer` (bytes32) is NOT discriminating: main's helper-based version kills the same mutant.
- Mutations applied: `src/lib/LibUint256Array.sol:298` insert `mstore(0x40, add(mload(0x40), 0x20))` -> killed by `testTruncateToOwnLengthAccepted` (`truncate allocated: 11456 != 11488`), survives on main. `src/lib/LibBytes32Array.sol:375` insert `mstore(outputEnd, 0xDEAD)` -> killed by `testExtendInlineDoesNotWritePastFreeMemoryPointer` (`wrote past the free memory pointer: 0x..dead != 0x..f00d0001`) on both versions. `src/lib/LibBytes32Array.sol:358` `let newBaseSize := sub(baseEnd, base)` -> `let newBaseSize := 0x60` -> killed by `testSelfExtendBytes32DoublesTheContents` (`EvmError: StackOverflow`), survives on main's length-2 array.
- Oracle: the bytes32 half of each mirrored pair. `LibUint256Array` and `LibBytes32Array` are identical modulo the element type (normalise `bytes32`->`uint256`, diff to zero), so an assertion present on one side and absent on the other is a gap by construction, independent of what either implementation does. Allocation expectations come from `LibPointer.allocatedMemoryPointer()` and the array's own `endPointer()`, never from re-deriving the assembly's arithmetic.
- Category check: #73 asks for the uint256/bytes32 suite drift, enumerating six instances. Five were already fixed on main by #105 and `41513ab` (table above); the sixth is fixed here. The category rather than the list was covered by normalising and diffing all 14 mirrored pairs, which surfaced two further drifts the issue never enumerated - one in each direction - both fixed here. Every pair now diffs to zero. The issue's structural half, a mechanism that stops the mirror drifting again, is NOT in this PR and is filed separately.
