### PR TITLE
Pin off stride sentinel data and the below lower boundary

### DIFF
--- a/test/src/lib/LibStackSentinel.t.sol
+++ b/test/src/lib/LibStackSentinel.t.sol
@@ -255,6 +255,39 @@ contract LibStackSentinelTest is Test {
         (tuplesPointer);
     }
 
+    /// An occurrence of the sentinel VALUE above the terminator that is off the
+    /// tuple stride is tuple data, not a terminator, and is built into the
+    /// tuples untouched.
+    function testConsumeSentinelTuplesOffStrideSentinelIsData(Sentinel sentinel, uint256 item) external pure {
+        vm.assume(Sentinel.unwrap(sentinel) != item);
+
+        Pointer lower;
+        assembly ("memory-safe") {
+            lower := mload(0x40)
+            mstore(0x40, add(lower, 0xa0))
+            // The scan probes two words apart down from `upper`, so it lands on
+            // words 4, 2 and 0. Word 2 terminates it and the sentinel at word 3
+            // is never probed.
+            mstore(lower, item)
+            mstore(add(lower, 0x20), item)
+            mstore(add(lower, 0x40), sentinel)
+            mstore(add(lower, 0x60), sentinel)
+            mstore(add(lower, 0x80), item)
+        }
+
+        (Pointer sentinelPointer, Pointer tuplesPointer) =
+            lower.consumeSentinelTuples(lower.unsafeAddWords(5), sentinel, 2);
+        assertEq(Pointer.unwrap(sentinelPointer), Pointer.unwrap(lower.unsafeAddWords(2)));
+
+        uint256[2][] memory tuples;
+        assembly ("memory-safe") {
+            tuples := tuplesPointer
+        }
+        assertEq(tuples.length, 1);
+        assertEq(tuples[0][0], Sentinel.unwrap(sentinel));
+        assertEq(tuples[0][1], item);
+    }
+
     function consumeSentinelTuplesRawExternal(Pointer lower, Pointer upper, Sentinel sentinel, uint256 n)
         external
         pure
@@ -489,6 +522,42 @@ contract LibStackSentinelTest is Test {
         }
         assertEq(selector, UnalignedStackPointer.selector);
         assertEq(upper - lower, 0x30);
+    }
+
+    /// Stages a four word stack, zeroed, with the sentinel in the word
+    /// immediately below `lower`. Four words is a whole number of strides for
+    /// every `n` the caller passes, so a cursor that is not stopped at `lower`
+    /// steps exactly onto it and probes the word below.
+    function consumeSentinelTuplesBelowLowerNotFoundExternal(Sentinel sentinel, uint256 n)
+        external
+        pure
+        returns (Pointer, Pointer)
+    {
+        Pointer lower;
+        assembly ("memory-safe") {
+            let base := mload(0x40)
+            mstore(0x40, add(base, 0xc0))
+            mstore(base, sentinel)
+            lower := add(base, 0x20)
+            mstore(lower, 0)
+            mstore(add(lower, 0x20), 0)
+            mstore(add(lower, 0x40), 0)
+            mstore(add(lower, 0x60), 0)
+        }
+        return lower.consumeSentinelTuples(lower.unsafeAddWords(4), sentinel, n);
+    }
+
+    /// A sentinel below `lower` is outside the range the caller described and is
+    /// not this stack's sentinel. The sentinel is non zero, so the boundary is
+    /// pinned without a zero sentinel colliding with zeroed memory.
+    function testConsumeSentinelTuplesBelowLowerNotFound(Sentinel sentinel) external {
+        vm.assume(Sentinel.unwrap(sentinel) != 0);
+
+        vm.expectRevert(abi.encodeWithSelector(MissingSentinel.selector, sentinel));
+        this.consumeSentinelTuplesBelowLowerNotFoundExternal(sentinel, 1);
+
+        vm.expectRevert(abi.encodeWithSelector(MissingSentinel.selector, sentinel));
+        this.consumeSentinelTuplesBelowLowerNotFoundExternal(sentinel, 2);
     }
 
     /// Neither pointer needs to be aligned in absolute terms, only with each


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.solmem/issues/71

## Verified against main

The issue names four gaps. Two are already closed on main, two are live.

**`unsafeList` at its documented maximum — moot.** `src/lib/LibStackPointer.sol` and its test file were deleted in 07e18be ("Delete LibStackPointer, dead across the whole org", 2026-08-15). `grep -r unsafeList` returns nothing. There is no code to test.

**`n == 1` — already covered.** `testConsumeSentinelTuplesSharedSubWordOffset` (added 0160c9c, 2026-07-29, after this issue was filed) builds a two tuple `n == 1` list and asserts its length and both items. Probe: `uint256 size = n * 0x20` -> `uint256 size = n == 1 ? 0x40 : n * 0x20`, which is invisible at every other `n`. It is killed on main by four tests: `testConsumeSentinelTuplesSharedSubWordOffset`, `testConsumeSentinelTuplesMultiSize`, `testConsumeSentinelTuplesMultiple` and `testConsumeSentinelTuplesNegativeStrideCannotSucceedSilently` (whose control scan is `n == 1`).

**A sentinel valued word as tuple DATA — live.** Every value asserting test opens with `vm.assume(stack[i] != Sentinel.unwrap(sentinel))`, so no test ever puts the sentinel VALUE off the stride above the terminator. M1 below survives the entire suite on main.

**The below `lower` boundary — live.** `testConsumeSentinelTuplesBelowLower` on main stages a word unaligned pair and now asserts `UnalignedStackPointer`, so it never reaches the scan at all. M2 below is killed on main only by collisions: `testConsumeSentinelTuplesEmptyError` on the `sentinel == 0` draw, and `testConsumeSentinelTuplesMissingSentinel` on the draw where `sentinel` happens to equal `stack.length`, because the word below `lower` is the source array's length slot. A `sentinel != 0` assume, or a stack whose length is never drawn as the sentinel, removes all of it.

## Changed

`test/src/lib/LibStackSentinel.t.sol` only. No source change.

- `testConsumeSentinelTuplesOffStrideSentinelIsData` — five staged words, `n == 2`, sentinel at words 2 and 3. The probes land on words 4, 2 and 0, so word 2 terminates the scan and the sentinel at word 3 is returned as `tuples[0][0]`.
- `consumeSentinelTuplesBelowLowerNotFoundExternal` + `testConsumeSentinelTuplesBelowLowerNotFound` — a zeroed four word stack with the sentinel in the word immediately below `lower`, run at `n == 1` and `n == 2`. Four words is a whole number of strides for both, so a cursor not stopped at `lower` steps exactly onto it and probes the word below. The sentinel is assumed non zero.

## Mutation table

Both mutants applied to `src/lib/LibStackSentinel.sol`, whole suite run each time with `nix develop -c forge test --match-path 'test/src/lib/LibStackSentinel*'`, `fuzz.runs = 2056`.

| # | Mutation | On main (without these tests) | With these tests |
| --- | --- | --- | --- |
| M1 | second pass guard `lt(cursor, upper)` -> `and(lt(cursor, upper), iszero(eq(mload(cursor), sentinel)))`, i.e. the tuple builder re-checks values and stops at a sentinel valued word | **SURVIVED** — 23 passed, 0 failed | **KILLED** by `testConsumeSentinelTuplesOffStrideSentinelIsData`, the only failure (24 passed, 1 failed) |
| M2 | first pass guard `gt(cursor, lower)` -> `iszero(lt(cursor, lower))`, i.e. the scan probes one word below `lower` | KILLED, but only by collision: `testConsumeSentinelTuplesEmptyError` at `sentinel == 0` (`args=[0]`) and `testConsumeSentinelTuplesMissingSentinel` at `sentinel == stack.length` (both `0xa8`), at run 59 of 2056 | **KILLED** by `testConsumeSentinelTuplesBelowLowerNotFound` as well; run alone under M2 it fails on the first draw, `args=[3]` |
| M3 | `uint256 size = n * 0x20` -> `n == 1 ? 0x40 : n * 0x20` (probe for the `n == 1` claim, not a defect) | KILLED on main by 4 tests, so `n == 1` needs nothing | unchanged |

Both new tests ran 2056/2056 and pass on the unmutated tree:

```
[PASS] testConsumeSentinelTuplesBelowLowerNotFound(uint256) (runs: 2056, μ: 8650, ~: 8650)
[PASS] testConsumeSentinelTuplesOffStrideSentinelIsData(uint256,uint256) (runs: 2056, μ: 4604, ~: 4604)
```

## QA
- Discriminating tests: `testConsumeSentinelTuplesOffStrideSentinelIsData`, `testConsumeSentinelTuplesBelowLowerNotFound` - each fails on unmodified main under the mutant it targets (M1 survives main without the first; M2 run alone with only the second fails on its first draw), and each passes 2056/2056 on the unmutated tree.
- Mutations applied: `LibStackSentinel.sol:232` second pass guard `lt(cursor, upper)` -> `and(lt(cursor, upper), iszero(eq(mload(cursor), sentinel)))` -> killed by `testConsumeSentinelTuplesOffStrideSentinelIsData` (sole failure); `LibStackSentinel.sol:198` first pass guard `gt(cursor, lower)` -> `iszero(lt(cursor, lower))` -> killed by `testConsumeSentinelTuplesBelowLowerNotFound`; `LibStackSentinel.sol:181` `n * 0x20` -> `n == 1 ? 0x40 : n * 0x20` -> already killed on main by 4 tests (probe only, no code change follows from it).
- Oracle: the NatSpec contract, not the implementation. `sentinelPointer` is stated to be ALWAYS within `[lower, upper)`, which fixes the word below `lower` as not the caller's sentinel; the sentinel terminates the scan only where the stride probes, which fixes an off stride occurrence above the terminator as tuple data. Expected pointers and tuple contents are computed by hand from the staged layout in each test.
- Category check: issue asks (a) `n == 1`, (b) sentinel valued tuple data, (c) below `lower` with a non zero sentinel, (d) `unsafeList` at maximum length; covered (b) and (c). (a) is already covered on main and (d) has no code left - both evidenced above.
