### PR TITLE
README: the library surface that exists, and the error surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ arrays/matrices that don't go through Solidity's safety-checked allocator.
 | ------------------ | ------------------------------------------------------------------------- |
 | `LibPointer`       | Raw memory pointer arithmetic, with explicit `Pointer` user-defined type. |
 | `LibMemCpy`        | Word-aligned and byte-aligned `memcpy` between memory pointers.           |
-| `LibBytes`         | In-place mutation, slicing, and pointer-level access for `bytes`.         |
-| `LibUint256Array`  | Dynamic `uint256[]` operations: extend, copy, dedup-sort, truncate.       |
+| `LibBytes`         | In-place `truncate`, plus start/data/end/allocated pointers.              |
+| `LibUint256Array`  | `arrayFrom` literals, `unsafeExtend`, `truncate`, `reverse`, pointers.    |
 | `LibBytes32Array`  | Dynamic `bytes32[]` mirror of `LibUint256Array`.                          |
 | `LibUint256Matrix` | `uint256[][]` operations.                                                 |
 | `LibBytes32Matrix` | `bytes32[][]` operations.                                                 |
@@ -18,6 +18,22 @@ arrays/matrices that don't go through Solidity's safety-checked allocator.
 
 These libraries assume the caller knows what they're doing with memory. Out-of-
 bounds access, double-frees, and aliasing are the caller's responsibility.
+
+## Errors
+
+| Error                   | Import from                     | Thrown by                                |
+| ----------------------- | ------------------------------- | ---------------------------------------- |
+| `TruncateError`         | `src/error/ErrBytes.sol`        | `LibBytes.truncate`                      |
+| `OutOfBoundsTruncate`   | `src/error/ErrUint256Array.sol` | `truncate` on both array libs            |
+| `UnalignedStackPointer` | `src/error/ErrStackPointer.sol` | `LibStackSentinel.consumeSentinelTuples` |
+| `ZeroSentinelTupleSize` | `src/lib/LibStackSentinel.sol`  | `LibStackSentinel.consumeSentinelTuples` |
+| `MissingSentinel`       | `src/lib/LibStackSentinel.sol`  | `LibStackSentinel.consumeSentinelTuples` |
+| `InvalidStackBounds`    | `src/lib/LibStackSentinel.sol`  | `LibStackSentinel.consumeSentinelTuples` |
+| `UnallocatedStack`      | `src/lib/LibStackSentinel.sol`  | `LibStackSentinel.consumeSentinelTuples` |
+
+`itemCount` and `flatten` on both matrix libs, and
+`LibStackSentinel.consumeSentinelTuples`, also revert with `Panic(uint256)` code
+`0x11` on arithmetic overflow.
 
 ## Requirements
 


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.solmem/issues/81

## Verified against main (`9a238f4`)

The issue is from 2026-07-25 and main has moved a lot since, so every claim was rechecked rather than taken on trust.

| Claim in the issue | State on main |
| --- | --- |
| `LibBytes` row advertises "slicing" | **Still live.** `LibBytes` is `truncate`, `dataPointer`, `startPointer`, `endDataPointer`, `endAllocatedPointer`. No slice, substring or copy-range. |
| `LibUint256Array` row advertises "copy" and "dedup-sort" | **Still live.** `grep -rn 'dedup\|sort\|copyTo' src/` is empty. The library is pointers, `unsafeAsUint256Array`, ten `arrayFrom` overloads, `truncate`, `unsafeExtend`, `reverse`. |
| README documents no error surface | **Still live.** The file does not name a single error. |
| "six custom errors" | **Stale — there are seven.** `UnallocatedStack` was added to `LibStackSentinel` after the issue was filed. |
| `UnalignedStackPointer` is thrown by `LibStackPointer.toIndexSigned` | **Stale.** `LibStackPointer` was deleted in `07e18be` ("Delete LibStackPointer, dead across the whole org"). `src/error/ErrStackPointer.sol` survived and the error is now imported and thrown by `LibStackSentinel.consumeSentinelTuples`. |

So the issue's proposed diff is applied, with the error table corrected to the seven errors main actually has and to the function that actually throws each.

The other six rows of the library table were checked too. None of them names an operation that does not exist, so none of them changed.

## Changed

`README.md` only. No source, no tests.

- The two rows that named operations the library does not have now name the operations it does.
- New `## Errors` section: every custom error, the path it is importable from, and the function that throws it. The `src/error/` vs inline-in-`LibStackSentinel` split the issue complains about is now the `Import from` column instead of something to find by reading source.
- One line for the `Panic(uint256)` `0x11` surface, which an `expectRevert` also has to match.

Nothing binds this with a test, per the standing ruling. README tests were stripped from this repo in `c2a7cf5`.

## Mutation

No behaviour changed, so there is no mutant of this diff a test could kill. What is falsifiable here is whether the table's claims are true, so that is what was mutated.

The `Import from` column was checked by compiling a throwaway contract (`scratch-verify/ReadmeErrorSurface.sol`, **not committed**, deleted after the run) that imports all seven errors from the exact paths the README gives and takes each `.selector`, then mutating those paths.

| # | Mutation | `nix develop -c forge build --contracts scratch-verify` |
| --- | --- | --- |
| — | baseline: all seven imported from the paths the README gives | `Compiling 70 files with Solc 0.8.25` / `Solc 0.8.25 finished in 53.93s` / `Compiler run successful!` — **compiles** |
| M1 | `ZeroSentinelTupleSize`, `MissingSentinel`, `InvalidStackBounds`, `UnallocatedStack` imported from `src/error/ErrStackPointer.sol` instead of `src/lib/LibStackSentinel.sol` | `Error: Compiler run failed:` / `Error (2904): Declaration "ZeroSentinelTupleSize" not found in "src/error/ErrStackPointer.sol"` (plus the same for `MissingSentinel` and `InvalidStackBounds`) — **KILLED** |
| M2 | `TruncateError` imported from `src/error/ErrUint256Array.sol` instead of `src/error/ErrBytes.sol` | `Error: Compiler run failed:` / `Error (2904): Declaration "TruncateError" not found in "src/error/ErrUint256Array.sol"` — **KILLED** |

Both mutants fail to compile, so the baseline pass is discriminating rather than vacuous: the compile really does resolve each name against the file the README names, and a wrong path in that column would not survive.

The `Thrown by` column is covered by tests already on main. Every one of the seven errors has at least one `expectRevert` against it, in the test file for the library the README attributes it to.

| Error | Existing `expectRevert` sites |
| --- | --- |
| `TruncateError` | 2, `test/src/lib/LibBytes.t.sol` |
| `OutOfBoundsTruncate` | 6, across `test/src/lib/LibUint256Array.truncate.t.sol` and `test/src/lib/LibBytes32Array.truncate.t.sol` |
| `UnalignedStackPointer` | 1, `test/src/lib/LibStackSentinel.t.sol` |
| `ZeroSentinelTupleSize` | 2, `test/src/lib/LibStackSentinel.t.sol` |
| `MissingSentinel` | 4, `test/src/lib/LibStackSentinel.t.sol` |
| `InvalidStackBounds` | 1, `test/src/lib/LibStackSentinel.t.sol` |
| `UnallocatedStack` | 1, `test/src/lib/LibStackSentinel.t.sol` |

The `Panic(uint256)` `0x11` line is pinned for `itemCount` on both matrix libs by `testUint256ItemCountOverflowRevertsWithArithmeticPanic` and `testBytes32ItemCountOverflowRevertsWithArithmeticPanic` in `test/src/lib/LibMatrix.flattenWrap.t.sol`. For `flatten` and `consumeSentinelTuples` it is the checked `* 0x20` each already documents in its own NatSpec.

## Conflicts

#124 and #125 also touch `README.md`. #124 is inside `## Develop`, no overlap. #125 rewrites the paragraph immediately above the new `## Errors` heading. Whichever lands second, I merge main in.

## QA
- Discriminating tests: n/a for the diff — it is docs-only, and the standing ruling forbids a test that reads or asserts prose (README tests were stripped from this repo in `c2a7cf5`). The discriminating artefact used instead was the throwaway `scratch-verify/ReadmeErrorSurface.sol`, which fails to compile for any wrong `Import from` path (see M1/M2 above) and is not committed.
- Mutations applied: M1 — the four `LibStackSentinel` inline errors imported from `src/error/ErrStackPointer.sol` -> killed by `forge build`, `Error (2904): Declaration "ZeroSentinelTupleSize" not found in "src/error/ErrStackPointer.sol"`. M2 — `TruncateError` imported from `src/error/ErrUint256Array.sol` -> killed by `forge build`, `Error (2904): Declaration "TruncateError" not found in "src/error/ErrUint256Array.sol"`. Baseline compiled 70 files successfully, so neither kill is a vacuous no-match.
- Oracle: `src/` itself, read independently of the README — the declaration site of each error, the `revert` statements in `src/lib/`, and the existing `expectRevert` assertions in `test/src/lib/`. Not the issue text, which is stale on two points (six errors vs seven; `LibStackPointer.toIndexSigned`, deleted in `07e18be`).
- Category check: the issue asks for A) the `LibBytes` row corrected, B) the `LibUint256Array` row corrected, C) the error surface documented including the `src/error/` vs inline split. All three covered. Widened past the examples: every other row of the library table was checked for the same defect (naming an operation that does not exist) and none has it, and the `Panic(uint256)` `0x11` revert surface is documented alongside the custom errors because `expectRevert` has to match it too.
