### PR TITLE
Keep the in place extend inside the heap

### DIFF
--- a/src/lib/LibBytes32Array.sol
+++ b/src/lib/LibBytes32Array.sol
@@ -323,7 +323,8 @@ library LibBytes32Array {
     /// the extend array after calling this function as it is never mutated, it
     /// is only copied from. Extending an array by itself therefore always
     /// allocates, as the in place path would rewrite the length word that base
-    /// and extend share.
+    /// and extend share. An uninitialised base also always allocates, as it
+    /// points at the permanently zero slot rather than at an allocation.
     ///
     /// Both arrays MUST be valid solidity memory arrays, each owning the region
     /// its own length word describes.
@@ -342,16 +343,20 @@ library LibBytes32Array {
                 let baseLength := mload(base)
                 let baseEnd := add(base, add(0x20, mul(baseLength, 0x20)))
 
-                // The in place path rewrites base's length word where it sits,
-                // and when extend IS base that word is also extend's length
-                // word, so the write would mutate extend. The in place path is
-                // therefore only taken when base is the last thing in allocated
-                // memory AND extend is a different array. Otherwise allocate,
-                // copy and recurse. The copy puts base above every existing
+                // The in place path rewrites base's length word where it sits.
+                // Below 0x80 there is no heap, only scratch space, the free
+                // memory pointer and the permanently zero slot that every
+                // uninitialised array points at, so a base there has no length
+                // word of its own to rewrite. When extend IS base that word is
+                // also extend's length word, so the write would mutate extend.
+                // The in place path is therefore only taken when base is a heap
+                // allocation that is the last thing in allocated memory AND
+                // extend is a different array. Otherwise allocate, copy and
+                // recurse. The copy puts base in the heap above every existing
                 // allocation, where it is both the last allocation and distinct
                 // from extend, so the recursion is one deep and lands on the in
                 // place path.
-                switch and(eq(outputCursor, baseEnd), iszero(eq(base, extend)))
+                switch and(and(eq(outputCursor, baseEnd), iszero(lt(base, 0x80))), iszero(eq(base, extend)))
                 case 0 {
                     let newBase := outputCursor
                     // Base size includes the length word and is in bytes.

--- a/src/lib/LibUint256Array.sol
+++ b/src/lib/LibUint256Array.sol
@@ -323,7 +323,8 @@ library LibUint256Array {
     /// the extend array after calling this function as it is never mutated, it
     /// is only copied from. Extending an array by itself therefore always
     /// allocates, as the in place path would rewrite the length word that base
-    /// and extend share.
+    /// and extend share. An uninitialised base also always allocates, as it
+    /// points at the permanently zero slot rather than at an allocation.
     ///
     /// Both arrays MUST be valid solidity memory arrays, each owning the region
     /// its own length word describes.
@@ -342,16 +343,20 @@ library LibUint256Array {
                 let baseLength := mload(base)
                 let baseEnd := add(base, add(0x20, mul(baseLength, 0x20)))
 
-                // The in place path rewrites base's length word where it sits,
-                // and when extend IS base that word is also extend's length
-                // word, so the write would mutate extend. The in place path is
-                // therefore only taken when base is the last thing in allocated
-                // memory AND extend is a different array. Otherwise allocate,
-                // copy and recurse. The copy puts base above every existing
+                // The in place path rewrites base's length word where it sits.
+                // Below 0x80 there is no heap, only scratch space, the free
+                // memory pointer and the permanently zero slot that every
+                // uninitialised array points at, so a base there has no length
+                // word of its own to rewrite. When extend IS base that word is
+                // also extend's length word, so the write would mutate extend.
+                // The in place path is therefore only taken when base is a heap
+                // allocation that is the last thing in allocated memory AND
+                // extend is a different array. Otherwise allocate, copy and
+                // recurse. The copy puts base in the heap above every existing
                 // allocation, where it is both the last allocation and distinct
                 // from extend, so the recursion is one deep and lands on the in
                 // place path.
-                switch and(eq(outputCursor, baseEnd), iszero(eq(base, extend)))
+                switch and(and(eq(outputCursor, baseEnd), iszero(lt(base, 0x80))), iszero(eq(base, extend)))
                 case 0 {
                     let newBase := outputCursor
                     // Base size includes the length word and is in bytes.

--- a/test/src/lib/LibBytes32Array.extend.t.sol
+++ b/test/src/lib/LibBytes32Array.extend.t.sol
@@ -106,4 +106,46 @@ contract LibBytes32ArrayExtendTest is Test {
         b[3] = bytes32(uint256(0x70));
         testExtendAllocate(a, b);
     }
+
+    /// An uninitialised array points at the permanently zero slot at 0x60, and
+    /// in a frame that has allocated nothing the free memory pointer sits
+    /// exactly at the end of it. The in place path would rewrite the zero slot
+    /// there, so an uninitialised base allocates instead: the slot stays zero
+    /// and every later empty array in the frame still reads a zero length
+    /// through it.
+    function testExtendUninitialisedBaseNeverWritesTheZeroSlot() public pure {
+        bytes32[] memory base;
+        bytes32[] memory extend;
+
+        // Deliberately NOT ("memory-safe"): extend is put in the scratch space
+        // so that nothing is allocated and the free memory pointer stays at the
+        // end of the zero slot base points at. The pointer is read here rather
+        // than after the call because assertions allocate.
+        uint256 fmpAtCall;
+        assembly {
+            mstore(0x00, 1)
+            mstore(0x20, 0xDEADBEEF)
+            extend := 0x00
+            fmpAtCall := mload(0x40)
+        }
+
+        bytes32[] memory extended = LibBytes32Array.unsafeExtend(base, extend);
+
+        bytes32[] memory later;
+        uint256 zeroSlot;
+        uint256 laterLength;
+        uint256 extendedPointer;
+        assembly {
+            zeroSlot := mload(0x60)
+            laterLength := mload(later)
+            extendedPointer := extended
+        }
+
+        assertEq(fmpAtCall, 0x80, "base must be the last thing below the free memory pointer");
+        assertEq(extendedPointer, 0x80, "the copy must land at the bottom of the heap");
+        assertEq(zeroSlot, 0, "zero slot written");
+        assertEq(laterLength, 0, "a later empty array must still read a zero length");
+        assertEq(extended.length, 1, "length");
+        assertEq(extended[0], bytes32(uint256(0xDEADBEEF)), "0");
+    }
 }

--- a/test/src/lib/LibUint256Array.extend.t.sol
+++ b/test/src/lib/LibUint256Array.extend.t.sol
@@ -106,4 +106,46 @@ contract LibUint256ArrayExtendTest is Test {
         b[3] = 0x70;
         testExtendAllocate(a, b);
     }
+
+    /// An uninitialised array points at the permanently zero slot at 0x60, and
+    /// in a frame that has allocated nothing the free memory pointer sits
+    /// exactly at the end of it. The in place path would rewrite the zero slot
+    /// there, so an uninitialised base allocates instead: the slot stays zero
+    /// and every later empty array in the frame still reads a zero length
+    /// through it.
+    function testExtendUninitialisedBaseNeverWritesTheZeroSlot() public pure {
+        uint256[] memory base;
+        uint256[] memory extend;
+
+        // Deliberately NOT ("memory-safe"): extend is put in the scratch space
+        // so that nothing is allocated and the free memory pointer stays at the
+        // end of the zero slot base points at. The pointer is read here rather
+        // than after the call because assertions allocate.
+        uint256 fmpAtCall;
+        assembly {
+            mstore(0x00, 1)
+            mstore(0x20, 0xDEADBEEF)
+            extend := 0x00
+            fmpAtCall := mload(0x40)
+        }
+
+        uint256[] memory extended = LibUint256Array.unsafeExtend(base, extend);
+
+        uint256[] memory later;
+        uint256 zeroSlot;
+        uint256 laterLength;
+        uint256 extendedPointer;
+        assembly {
+            zeroSlot := mload(0x60)
+            laterLength := mload(later)
+            extendedPointer := extended
+        }
+
+        assertEq(fmpAtCall, 0x80, "base must be the last thing below the free memory pointer");
+        assertEq(extendedPointer, 0x80, "the copy must land at the bottom of the heap");
+        assertEq(zeroSlot, 0, "zero slot written");
+        assertEq(laterLength, 0, "a later empty array must still read a zero length");
+        assertEq(extended.length, 1, "length");
+        assertEq(extended[0], 0xDEADBEEF, "0");
+    }
 }


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.solmem/issues/65

## The defect

`unsafeExtend` takes its in place path when the free memory pointer sits exactly at the end of the base array. An **uninitialised** array (`uint256[] memory base;`) is not an allocation: Solidity points the reference at `0x60`, the permanently zero slot. Its length word reads `0`, so `baseEnd = 0x60 + 0x20 + 0 = 0x80`, and in a frame that has allocated nothing `mload(0x40)` is exactly `0x80`. The equality held, the in place branch ran, and `mstore(base, totalLength)` wrote the new length **to `0x60`**.

Two things break when it does. Every later empty dynamic array in the frame reads its length through `0x60`, so once that slot is non-zero they all report a bogus length. And the `assembly ("memory-safe")` annotation on the block becomes false: `0x60` is not memory the block allocated, not inside an array it was handed, not scratch space, and not above the free memory pointer.

Reachability is narrow, which is why #65 is rated LOW. A non-zero `extendLength` requires the extend array to come from an unsafe cast, because any normally allocated extend array would already have moved `mload(0x40)` past `0x80` and forced the copy branch. With both arrays uninitialised the write is `0` over `0` — harmless in effect, still an annotation violation.

## The fix

The in place path now additionally requires the base to sit in the heap:

```solidity
switch and(and(eq(outputCursor, baseEnd), iszero(lt(base, 0x80))), iszero(eq(base, extend)))
```

`0x80` is the heap floor. Below it there is only scratch space (`0x00`–`0x3f`), the free memory pointer (`0x40`) and the zero slot (`0x60`); nothing down there has a length word of its own to rewrite. An uninitialised base now fails the guard and takes the allocate-and-copy branch, which was already correct for it — the copy lands at `mload(0x40)`, at or above `0x80` by construction, and the one-deep recursion then finds a base that is both a real allocation and the last one, so it takes the in place path there.

#65 proposed `gt(base, 0x60)`. This ships `iszero(lt(base, 0x80))` instead, which is strictly stronger and names the actual boundary — `gt(base, 0x60)` would still admit a base at `0x61`–`0x7f`, which is below the heap.

## Changed

Four files.

- `src/lib/LibUint256Array.sol`, `src/lib/LibBytes32Array.sol` — the guard, plus the branch comment and one `unsafeExtend` natspec sentence, both rewritten to state that an uninitialised base always allocates.
- `test/src/lib/LibUint256Array.extend.t.sol`, `test/src/lib/LibBytes32Array.extend.t.sol` — `testExtendUninitialisedBaseNeverWritesTheZeroSlot`, one per element type.

The test builds the exact hazardous frame: base uninitialised at `0x60`, extend forced into the scratch space by a deliberately non-`memory-safe` assembly block so that **nothing** is allocated and `mload(0x40)` stays at `0x80`. It asserts the free memory pointer really was `0x80` at the call — without that the test could pass vacuously — then that the result landed at `0x80`, that `0x60` is still zero, that a later empty array still reads length `0`, and that the extend contents came through.

## QA

Everything below was run against **this** diff in the repo's own `nix develop` shell (rainix `sol-shell`): `forge 1.7.2-nightly` (`43923a4`), `solc 0.8.25` as pinned by `foundry.toml`, `evm_version = "cancun"`, optimizer on at 100000 runs.

The mutation runs were performed on a tree whose `src/` and `test/` are byte-identical to the merge commit `d30c60e` — `git diff --stat <tree> d30c60e -- src test` is empty. Only `README.md`, `audit/audits.json` and the `foundry.toml` version bump differ, none of which any test reads.

### Suite

| Tree | Result |
| --- | --- |
| `main` immediately before this PR (`ac5f083`) | 389 passed, 0 failed |
| merge commit (`d30c60e`) | 391 passed, 0 failed |

`+2`, both of them the new test; nothing removed, renamed or skipped.

### Static

- `slither .` — `. analyzed (8 contracts with 99 detectors), 0 result(s) found`.
- `forge fmt --check` — clean, exit 0, at `d30c60e`.
- `rainix-sol-single-contract` — **n/a**: the binary is not present in the flake's current `sol-shell` (CI pins a different rainix SHA), so it was not run. This diff adds and removes no file, so the one-contract-per-file convention is untouched either way.

### Mutation

Each mutation is applied to the guard in **both** libraries at once and the **whole** suite is run, so a survivor survived all 391 tests rather than a filter. Counts are test instances across both element types.

| Mutant | Guard becomes | Result | Evidence |
| --- | --- | --- | --- |
| M1 — guard deleted; this is exactly `main`'s condition | `and(eq(outputCursor, baseEnd), iszero(eq(base, extend)))` | **KILLED** | 389 passed, 2 failed — `[FAIL: the copy must land at the bottom of the heap: 96 != 128]` |
| M1b — M1 again, with the result-pointer assertion commented out so the zero slot is the first thing checked | as M1 | **KILLED** | `[FAIL: zero slot written: 1 != 0]` |
| M2 — floor lowered onto the zero slot | `iszero(lt(base, 0x60))` | **KILLED** | 389 passed, 2 failed — `96 != 128` |
| M3 — floor raised one word | `iszero(lt(base, 0xa0))` | **KILLED** | 389 passed, 2 failed — `160 != 128` |
| M4 — guard inverted | `lt(base, 0x80)` | **KILLED** | 353 passed, 38 failed — `EvmError: StackOverflow`, the allocate branch stops terminating |
| M5 — guard neutralised | `1` | **KILLED** | 389 passed, 2 failed |
| M6 — floor lowered to an address no Solidity array can occupy | `iszero(lt(base, 0x70))` | **SURVIVED** | 391 passed, 0 failed |

M1 is the row that matters: it *is* `main`'s source, and the two new tests are the only things in the entire suite that fail against it. M1b is the same mutant with the test's third assertion promoted, and it is what shows the defect #65 actually describes — the zero slot holding `1` instead of `0`. The shipped assertion order fires on the result pointer first; that assertion is not decoration, it is the only thing that kills M3.

**M6 survived and no test was added for it.** A floor of `0x70` still excludes `0x60`, so it is correct for every base a Solidity program can produce: the only sub-heap pointer a caller can obtain without an unsafe cast is `0x60`, and everything else is at or above `0x80`. Any floor in `0x61`–`0x80` is behaviourally identical under the library's stated contract ("Both arrays MUST be valid solidity memory arrays, each owning the region its own length word describes"). Killing M6 would mean fabricating a base at `0x70` with a hand-written length word straddling the zero slot and the heap floor, i.e. asserting on behaviour the contract already excludes. Recorded as an equivalent mutant, not a coverage gap.

### Gas

The guard costs one extra bounds test per `extendInline` invocation, and the allocating path invokes it twice. Deterministic tests only, `uint256` half, `ac5f083` → this diff:

| Test | before | after | Δ |
| --- | --- | --- | --- |
| `testExtendInlineBothEmptyKeepsBasePointer` | 861 | 876 | +15 |
| `testExtendInlineEmptyBaseKeepsBasePointer` | 1412 | 1427 | +15 |
| `testExtendInlineEmptyExtendKeepsBasePointer` | 1331 | 1369 | +38 |
| `testExtendAllocateBothEmptyAllocatesFreshRegion` | 1162 | 1192 | +30 |
| `testExtendAllocateEmptyExtendMovesBasePointer` | 1579 | 1609 | +30 |
| `testExtendAllocateEmptyBaseAllocatesFreshRegion` | 1665 | 1695 | +30 |
| `testExtendAllocateDebug` | 11010 | 11040 | +30 |

The `+38` does not fit the `+15`/`+30` pattern and is not a second guard evaluation. It was not investigated further.

### Mirror

The `bytes32` and `uint256` halves must not drift apart. This PR's diff hunks against `main`, taken per file and normalised `Bytes32`→`Uint256`, are identical between the two libraries and between the two test files, apart from the blob hash lines and one pre-existing context line (`b[3] = bytes32(uint256(0x70))` vs `b[3] = 0x70`) that this PR does not touch.

### Scope

`unsafeExtend` was the only function in `src/` that could write a non-zero value below `0x80`. The only other function storing through a caller-supplied array pointer is `truncate`, and a throwaway probe — written, run, discarded, not part of this diff — confirms it is safe by construction: an uninitialised array reports length `0`, so any `newLength > 0` reverts before the store, and `truncate(uninitialised, 0)` stores `0` over the already-zero slot, leaving `mload(0x60) == 0`. Every other `mstore(array, …)` in the two libraries is inside an `arrayFrom` variant, where `array` came from `mload(0x40)` and is therefore already at or above `0x80`.

---

*The previous text of this description belonged to a different PR (the #73 mirrored-test drift work) and described none of the above. Replaced.*
