### PR TITLE
Point the sentinel NatSpec at the errors and the pointer it actually returns

### DIFF
--- a/src/lib/LibStackSentinel.sol
+++ b/src/lib/LibStackSentinel.sol
@@ -89,8 +89,8 @@ library LibStackSentinel {
     using LibStackSentinel for Pointer;
 
     /// Given two stack pointers that bound a stack build an array of `n` item
-    /// tuples above the given sentinel value. The sentinel will be skipped and
-    /// a pointer below it returned alongside the tuples list.
+    /// tuples above the given sentinel value. The sentinel is excluded from the
+    /// tuples and a pointer TO it is returned alongside the tuples list.
     ///
     /// The tuples can be cast (via assembly) to structs.
     ///
@@ -101,24 +101,22 @@ library LibStackSentinel {
     /// a real value in the array, otherwise an intended array item will be
     /// interpreted as a sentinel.
     ///
-    /// If the sentinel is absent in the stack this WILL REVERT. The intent is
-    /// to represent dynamic length arrays without forcing expression authors to
-    /// calculate lengths on the stack. If the expression author wants to model
-    /// an empty/optional/absent value they MAY provided a sentinel for a zero
-    /// length array and the calling contract SHOULD handle this.
+    /// An expression author that wants to model an empty/optional/absent value
+    /// MAY provide a sentinel for a zero length array and the calling contract
+    /// SHOULD handle this.
     ///
     /// `n` is scaled to a byte stride in checked Solidity, so an `n` too large
     /// to scale (`n > type(uint256).max / 0x20`) WILL REVERT with an arithmetic
-    /// overflow panic. Together with `n != 0` that is the only bound on `n`.
-    /// There is no check that the stack is large enough to hold whole tuples of
-    /// that stride, so the scan steps down from `upper` in strides of
-    /// `n * 0x20` BYTES and a stride that the remaining range cannot be stepped
-    /// down by steps the cursor past zero and wraps it. There is no explicit
-    /// underflow check and the resulting failure is deliberately not uniform:
-    /// almost every wrapped cursor lands at an unaddressable position, where
-    /// the read exhausts the whole gas allowance of the call frame, but a
-    /// stride within a few words of `2**256` wraps to a small step UPWARD and
-    /// the scan reads above `upper` instead.
+    /// overflow panic. That and zero are the only bounds on `n`. There is no
+    /// check that the stack is large enough to hold whole tuples of that
+    /// stride, so the scan steps down from `upper` in strides of `n * 0x20`
+    /// BYTES and a stride that the remaining range cannot be stepped down by
+    /// steps the cursor past zero and wraps it. There is no explicit underflow
+    /// check and the resulting failure is deliberately not uniform: almost
+    /// every wrapped cursor lands at an unaddressable position, where the read
+    /// exhausts the whole gas allowance of the call frame, but a stride within
+    /// a few words of `2**256` wraps to a small step UPWARD and the scan reads
+    /// above `upper` instead.
     ///
     /// What IS guaranteed is that an underflowing scan cannot silently
     /// succeed. `sentinelPointer` is ALWAYS within `[lower, upper)`, and a scan
@@ -143,16 +141,19 @@ library LibStackSentinel {
     /// so the same stack without the sentinel in it reverts with
     /// `MissingSentinel` instead.
     ///
-    /// @param upper Pointer to the top of the stack range. MUST NOT be below
-    /// `lower`, MUST be a whole number of words above it, and MUST NOT be above
-    /// the allocated memory pointer.
-    /// @param lower Pointer to the bottom of the stack range.
+    /// @param lower Pointer to the bottom of the stack range. MUST NOT be above
+    /// `upper` or this reverts with `InvalidStackBounds`.
+    /// @param upper Pointer to the top of the stack range. MUST be a whole
+    /// number of words above `lower` and MUST NOT be above the allocated memory
+    /// pointer.
     /// @param sentinel The value to expect as the sentinel. MUST be present in
-    /// the stack or `consumeSentinel` will revert. MUST NOT collide with valid
-    /// stack items (or be cryptographically improbable to do so).
-    /// @param n The number of items per tuple.
-    /// @return sentinelPointer Pointer to the sentinel that was found, ALWAYS
-    /// within `[lower, upper)`. A missing sentinel WILL REVERT.
+    /// the stack ON A TUPLE BOUNDARY or this reverts with `MissingSentinel`.
+    /// MUST NOT collide with valid stack items (or be cryptographically
+    /// improbable to do so).
+    /// @param n The number of items per tuple. MUST NOT be zero or this reverts
+    /// with `ZeroSentinelTupleSize`.
+    /// @return sentinelPointer Pointer to the word holding the sentinel that
+    /// was found, ALWAYS within `[lower, upper)`.
     /// @return tuplesPointer Pointer to the n-item tuples array that was built.
     function consumeSentinelTuples(Pointer lower, Pointer upper, Sentinel sentinel, uint256 n)
         internal


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.solmem/issues/82

NatSpec only, `src/lib/LibStackSentinel.sol`. No executable change.

## Verified against main (9a238f4) first

Two of the five defects the issue lists were fixed on `main` after it was filed and are NOT touched here.

| Issue defect | State on `main` |
| --- | --- |
| 1. `MissingSentinel` documents an inverted-bounds trigger it can never have | **Already fixed.** The error doc now lists absent sentinel, off-boundary sentinel, and a sentinel found outside the bounds. Inverted bounds are not mentioned anywhere in it. |
| 2. Underflow precondition stated as `lower < n` instead of `lower < n * 0x20`, gas-exhaustion failure mode undocumented, same unit error mirrored in the test | **Already fixed.** The function doc states the stride in BYTES, the wrap past zero, the unaddressable read that exhausts the call frame's gas, the upward-wrap case, and that a caller MUST NOT depend on which failure it gets. `testConsumeSentinelTuplesUnderflowCannotSucceedSilently` now derives `n` so `n * 0x20 > upper`, i.e. every draw underflows on the first decrement rather than comparing a byte address against a tuple count. |
| 3. `@param` tags in reverse of the signature order | **Live.** `@param upper` preceded `@param lower`; the signature is `(Pointer lower, Pointer upper, ...)`. |
| 4. `ZeroSentinelTupleSize` and `InvalidStackBounds` undocumented on the function | **Live.** Both constraints were stated, neither error was named. |
| 5. Dangling `consumeSentinel`, summary contradicting `@return`, `MAY provided` | **Live.** All three. |

## Changed

- `@param` order now matches the signature, and `@param lower` names `InvalidStackBounds` on the constraint that triggers it.
- `@param n` names `ZeroSentinelTupleSize`.
- `@param sentinel` names `MissingSentinel` and states the tuple-boundary requirement. That replaces "or `consumeSentinel` will revert" — no such function exists.
- The summary said the sentinel "will be skipped and a pointer below it returned". The code returns the address of the word holding the sentinel, and `@return sentinelPointer` said so. The summary now agrees with the code and `@return` says "the word holding the sentinel".
- `MAY provided` -> `MAY provide`. The sentence in front of it restated the missing-sentinel revert that `@param sentinel` now owns, plus a rationale clause for why sentinels exist at all, so both are gone.
- `Together with n != 0 that is the only bound on n` -> `That and zero are the only bounds on n`, so the zero rule lives only on `@param n`.

## QA

- **Discriminating tests:** n/a — no test is added or changed. The diff is NatSpec only and this org's ruling forbids tests that read or assert prose, so the claims are pinned by mutating the CODE until each claim is false and showing the EXISTING suite fails. Baseline `nix develop -c forge test` on the branch: `349 tests passed, 0 failed`. Every mutation ran `--match-path 'test/src/lib/LibStackSentinel*'`, which reports `27 total tests` on every single run, so no run was a zero-match no-op. 7 applied, 7 killed, 0 survived. Each mutation was `sed`ed onto the committed branch state, asserted to produce a non-empty `git diff` before the suite ran, and `git checkout`ed back after.

- **Mutations applied:**

| # | Claim the NatSpec now makes | Mutation | Suite | Killing tests |
| --- | --- | --- | --- | --- |
| M1 | summary "a pointer TO it is returned"; `@return sentinelPointer Pointer to the word holding the sentinel` | `sentinelPointer := potentialSentinelPointer` -> `sentinelPointer := sub(potentialSentinelPointer, 0x20)`, i.e. return the word BELOW the sentinel exactly as the old summary claimed | 19 passed, **8 failed**, 27 total | `testConsumeSentinelTuples`, `testConsumeSentinelTuples3`, `testConsumeSentinelTuplesEmpty`, `testConsumeSentinelTuplesMultiSize`, `testConsumeSentinelTuplesMultiple`, `testConsumeSentinelTuplesNegativeStrideCannotSucceedSilently` |
| M2 | `@param lower ... MUST NOT be above upper or this reverts with InvalidStackBounds` | `revert InvalidStackBounds(lower, upper);` -> `revert MissingSentinel(sentinel);` | 26 passed, **1 failed**, 27 total | `testConsumeSentinelTuplesInvertedBoundsError` |
| M3 | `@param n ... MUST NOT be zero or this reverts with ZeroSentinelTupleSize` | `revert ZeroSentinelTupleSize();` -> `revert MissingSentinel(sentinel);` | 25 passed, **2 failed**, 27 total | `testConsumeSentinelTuplesNZeroError`, `testConsumeSentinelTuplesNZeroErrorPrecedence` |
| M4 | `@param sentinel ... MUST be present in the stack ON A TUPLE BOUNDARY or this reverts with MissingSentinel` | scan stride `{ cursor := sub(cursor, size) }` -> `{ cursor := sub(cursor, 0x20) }`, so an off-boundary sentinel is found instead of stepped over | 25 passed, **2 failed**, 27 total | `testConsumeSentinelTuplesOddSentinel`, `testConsumeSentinelTuplesNonWrappingOversizedTupleFailsLoudly` |
| M5 | `@return sentinelPointer ... ALWAYS within [lower, upper)` | drop ` \|\| Pointer.unwrap(sentinelPointer) >= Pointer.unwrap(upper)` from the range check | 26 passed, **1 failed**, 27 total | `testConsumeSentinelTuplesNegativeStrideCannotSucceedSilently` |
| M6 | "`n` is scaled to a byte stride in checked Solidity ... WILL REVERT with an arithmetic overflow panic. That and zero are the only bounds on `n`." | `uint256 size = n * 0x20;` -> `uint256 size; unchecked { size = n * 0x20; }` | 24 passed, **3 failed**, 27 total | `testConsumeSentinelTuplesWrappedSizeAliasesTheSmallResidue`, `testConsumeSentinelTuplesWrappedSizeCollapsesAtEveryMultiple`, `testConsumeSentinelTuplesWrappedSizeReturnsMoreTuplesThanTheStackHolds` |
| M7 | summary "The sentinel is excluded from the tuples" | second pass start `let cursor := add(sentinelPointer, 0x20) }` -> `let cursor := sentinelPointer }` | 20 passed, **7 failed**, 27 total | `testConsumeSentinelTuples`, `testConsumeSentinelTuples3`, `testConsumeSentinelTuplesEmpty`, `testConsumeSentinelTuplesMultiSize`, `testConsumeSentinelTuplesMultiple`, `testConsumeSentinelTuplesSharedSubWordOffset` |

  M1 and M7 name six of their eight and seven failures respectively; the harness capped the captured `[FAIL` lines at six. The suite totals are the authority on the count.

- **Oracle:** independent of the doc under change. `@param` order is checked against the function signature; the error names against the four `error` declarations at the top of the same file; the returned pointer, the tuple-boundary rule, the range guarantee and the checked-`mul` behaviour against what the mutations prove the code does. What HAD to change came from the issue's five enumerated defects, each re-read against `main` before anything was edited.

- **Category check:** issue asks 1, 2, 3, 4, 5. Defects 1 and 2 were already satisfied on `main` with the evidence in the table above and are deliberately not re-fixed. Defects 3, 4 and 5 are covered here in full — 5 includes all three of its parts (dangling `consumeSentinel`, the summary/`@return` contradiction, and `MAY provided`). The issue's proposed text for the `MissingSentinel` declaration also suggested naming `InvalidStackBounds` there as the error inverted bounds DO produce; that need is met on the function doc instead, where `@param lower` now names it, so a consumer classifying by selector reads it off the parameter it constrains.
