### PR TITLE
Pin the empty-base and both-empty shapes of unsafeExtend

### DIFF
--- a/test/src/lib/LibBytes32Array.extend.t.sol
+++ b/test/src/lib/LibBytes32Array.extend.t.sol
@@ -94,6 +94,81 @@ contract LibBytes32ArrayExtendTest is Test {
         assertNotEq(baseBefore, Pointer.unwrap(LibBytes32Array.startPointer(extended)), "allocate path not taken");
     }
 
+    /// An empty base contributes nothing, so the extended array is the extend
+    /// array's contents. The inline path returns the pointer it was given.
+    function testExtendInlineEmptyBaseKeepsBasePointer() public pure {
+        bytes32[] memory extend = new bytes32[](2);
+        extend[0] = bytes32(uint256(0x44));
+        extend[1] = bytes32(uint256(0x55));
+
+        // Allocated last, so base is the most recent allocation.
+        bytes32[] memory base = new bytes32[](0);
+
+        uint256 baseBefore = Pointer.unwrap(LibBytes32Array.startPointer(base));
+        bytes32[] memory extended = LibBytes32Array.unsafeExtend(base, extend);
+
+        assertEq(extended.length, 2, "length");
+        assertEq(extended[0], bytes32(uint256(0x44)), "0");
+        assertEq(extended[1], bytes32(uint256(0x55)), "1");
+        assertEq(baseBefore, Pointer.unwrap(LibBytes32Array.startPointer(extended)), "inline path not taken");
+    }
+
+    /// The allocating counterpart of the case above. The result is a fresh
+    /// region aliasing neither input, so a later write through the result
+    /// cannot reach the extend array.
+    function testExtendAllocateEmptyBaseAllocatesFreshRegion() public pure {
+        bytes32[] memory base = new bytes32[](0);
+
+        // Allocated after base, so base is no longer the most recent
+        // allocation.
+        bytes32[] memory extend = new bytes32[](2);
+        extend[0] = bytes32(uint256(0x44));
+        extend[1] = bytes32(uint256(0x55));
+
+        uint256 baseBefore = Pointer.unwrap(LibBytes32Array.startPointer(base));
+        uint256 extendBefore = Pointer.unwrap(LibBytes32Array.startPointer(extend));
+        bytes32[] memory extended = LibBytes32Array.unsafeExtend(base, extend);
+
+        assertEq(extended.length, 2, "length");
+        assertEq(extended[0], bytes32(uint256(0x44)), "0");
+        assertEq(extended[1], bytes32(uint256(0x55)), "1");
+        assertNotEq(baseBefore, Pointer.unwrap(LibBytes32Array.startPointer(extended)), "allocate path not taken");
+        assertNotEq(extendBefore, Pointer.unwrap(LibBytes32Array.startPointer(extended)), "aliases extend");
+    }
+
+    /// Both arrays empty. Nothing is copied and the result is empty. The inline
+    /// path returns the pointer it was given.
+    function testExtendInlineBothEmptyKeepsBasePointer() public pure {
+        bytes32[] memory extend = new bytes32[](0);
+
+        // Allocated last, so base is the most recent allocation.
+        bytes32[] memory base = new bytes32[](0);
+
+        uint256 baseBefore = Pointer.unwrap(LibBytes32Array.startPointer(base));
+        bytes32[] memory extended = LibBytes32Array.unsafeExtend(base, extend);
+
+        assertEq(extended.length, 0, "length");
+        assertEq(baseBefore, Pointer.unwrap(LibBytes32Array.startPointer(extended)), "inline path not taken");
+    }
+
+    /// The allocating counterpart of the case above. Empty in, empty out, and
+    /// still a fresh region aliasing neither input.
+    function testExtendAllocateBothEmptyAllocatesFreshRegion() public pure {
+        bytes32[] memory base = new bytes32[](0);
+
+        // Allocated after base, so base is no longer the most recent
+        // allocation.
+        bytes32[] memory extend = new bytes32[](0);
+
+        uint256 baseBefore = Pointer.unwrap(LibBytes32Array.startPointer(base));
+        uint256 extendBefore = Pointer.unwrap(LibBytes32Array.startPointer(extend));
+        bytes32[] memory extended = LibBytes32Array.unsafeExtend(base, extend);
+
+        assertEq(extended.length, 0, "length");
+        assertNotEq(baseBefore, Pointer.unwrap(LibBytes32Array.startPointer(extended)), "allocate path not taken");
+        assertNotEq(extendBefore, Pointer.unwrap(LibBytes32Array.startPointer(extended)), "aliases extend");
+    }
+
     function testExtendAllocateDebug() public pure {
         bytes32[] memory a = new bytes32[](3);
         bytes32[] memory b = new bytes32[](4);

--- a/test/src/lib/LibUint256Array.extend.t.sol
+++ b/test/src/lib/LibUint256Array.extend.t.sol
@@ -94,6 +94,81 @@ contract LibUint256ArrayExtendTest is Test {
         assertNotEq(baseBefore, Pointer.unwrap(LibUint256Array.startPointer(extended)), "allocate path not taken");
     }
 
+    /// An empty base contributes nothing, so the extended array is the extend
+    /// array's contents. The inline path returns the pointer it was given.
+    function testExtendInlineEmptyBaseKeepsBasePointer() public pure {
+        uint256[] memory extend = new uint256[](2);
+        extend[0] = 0x44;
+        extend[1] = 0x55;
+
+        // Allocated last, so base is the most recent allocation.
+        uint256[] memory base = new uint256[](0);
+
+        uint256 baseBefore = Pointer.unwrap(LibUint256Array.startPointer(base));
+        uint256[] memory extended = LibUint256Array.unsafeExtend(base, extend);
+
+        assertEq(extended.length, 2, "length");
+        assertEq(extended[0], 0x44, "0");
+        assertEq(extended[1], 0x55, "1");
+        assertEq(baseBefore, Pointer.unwrap(LibUint256Array.startPointer(extended)), "inline path not taken");
+    }
+
+    /// The allocating counterpart of the case above. The result is a fresh
+    /// region aliasing neither input, so a later write through the result
+    /// cannot reach the extend array.
+    function testExtendAllocateEmptyBaseAllocatesFreshRegion() public pure {
+        uint256[] memory base = new uint256[](0);
+
+        // Allocated after base, so base is no longer the most recent
+        // allocation.
+        uint256[] memory extend = new uint256[](2);
+        extend[0] = 0x44;
+        extend[1] = 0x55;
+
+        uint256 baseBefore = Pointer.unwrap(LibUint256Array.startPointer(base));
+        uint256 extendBefore = Pointer.unwrap(LibUint256Array.startPointer(extend));
+        uint256[] memory extended = LibUint256Array.unsafeExtend(base, extend);
+
+        assertEq(extended.length, 2, "length");
+        assertEq(extended[0], 0x44, "0");
+        assertEq(extended[1], 0x55, "1");
+        assertNotEq(baseBefore, Pointer.unwrap(LibUint256Array.startPointer(extended)), "allocate path not taken");
+        assertNotEq(extendBefore, Pointer.unwrap(LibUint256Array.startPointer(extended)), "aliases extend");
+    }
+
+    /// Both arrays empty. Nothing is copied and the result is empty. The inline
+    /// path returns the pointer it was given.
+    function testExtendInlineBothEmptyKeepsBasePointer() public pure {
+        uint256[] memory extend = new uint256[](0);
+
+        // Allocated last, so base is the most recent allocation.
+        uint256[] memory base = new uint256[](0);
+
+        uint256 baseBefore = Pointer.unwrap(LibUint256Array.startPointer(base));
+        uint256[] memory extended = LibUint256Array.unsafeExtend(base, extend);
+
+        assertEq(extended.length, 0, "length");
+        assertEq(baseBefore, Pointer.unwrap(LibUint256Array.startPointer(extended)), "inline path not taken");
+    }
+
+    /// The allocating counterpart of the case above. Empty in, empty out, and
+    /// still a fresh region aliasing neither input.
+    function testExtendAllocateBothEmptyAllocatesFreshRegion() public pure {
+        uint256[] memory base = new uint256[](0);
+
+        // Allocated after base, so base is no longer the most recent
+        // allocation.
+        uint256[] memory extend = new uint256[](0);
+
+        uint256 baseBefore = Pointer.unwrap(LibUint256Array.startPointer(base));
+        uint256 extendBefore = Pointer.unwrap(LibUint256Array.startPointer(extend));
+        uint256[] memory extended = LibUint256Array.unsafeExtend(base, extend);
+
+        assertEq(extended.length, 0, "length");
+        assertNotEq(baseBefore, Pointer.unwrap(LibUint256Array.startPointer(extended)), "allocate path not taken");
+        assertNotEq(extendBefore, Pointer.unwrap(LibUint256Array.startPointer(extended)), "aliases extend");
+    }
+
     function testExtendAllocateDebug() public pure {
         uint256[] memory a = new uint256[](3);
         uint256[] memory b = new uint256[](4);


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.solmem/issues/76

## Verified against main first

The issue was filed against an older main and most of what it claims has since
landed. Checked at `9a238f4`:

- **"Exactly one of the twelve combinations has a deterministic test"** — false
  now. `testExtendInlineEmptyExtendKeepsBasePointer` and
  `testExtendAllocateEmptyExtendMovesBasePointer` exist in both
  `LibUint256Array.extend.t.sol` and `LibBytes32Array.extend.t.sol`, so all four
  empty-extend combinations are pinned deterministically, plus the empty-extend
  poison test in each `allocation.t.sol`.
- **"The one-word over-allocation mutant survives"** — false now. It is killed by
  `testExtendInlineAllocatesExactly`, `testExtendAllocateAllocatesExactly` and
  `testSelfExtendUint256AllocatesExactly` (M02 below). The issue's separate wish
  that "extending by an empty array on the inline branch must be a total no-op on
  the free memory pointer" is the same invariant: `fmp == endPointer(extended)`
  with an empty extend *is* `fmp` unmoved, and that equality is already asserted.
- **"Self-extension is only tested on the inline branch"** — false now, and
  inverted. #61 landed `iszero(eq(base, extend))` into the branch condition, so
  `base == extend` can no longer take the inline branch at all; every one of the
  ten tests in `LibArray.selfExtend.t.sol` exercises the copy-and-recurse branch.
  The issue's `mstore(base, 0)` mutant is killed by five of them (M01 below). The
  proposed spacer test is not added: with the aliasing guard in the condition, an
  aliased base takes the copy branch whether or not it is the last allocation, so
  a spacer changes no branch and no overlap (the copy destination is the free
  memory pointer, which is always at or above the base's end).

**What is still missing on main**: the empty-BASE and BOTH-EMPTY shapes. No
deterministic test anywhere constructs them; they are reached only when the two
100-run fuzz tests happen to draw a zero-length array.

## Changed

Four tests per element type, appended beside the existing empty-extend tests in
the file that mirrors the subject:

- `test/src/lib/LibUint256Array.extend.t.sol`
- `test/src/lib/LibBytes32Array.extend.t.sol`

`testExtendInlineEmptyBase…`, `testExtendAllocateEmptyBase…`,
`testExtendInlineBothEmpty…`, `testExtendAllocateBothEmpty…`. Each asserts the
contents, which branch actually ran, and — on the allocating branch — that the
result aliases neither input.

No source change.

## Mutation table

`mutation-probe` over `nix develop -c forge test`, `FOUNDRY_FUZZ_SEED=0x76`.
Baseline green both before (349 passed) and after (357 passed).

| # | mutant | before this PR | new tests only (8 tests) | after this PR |
|---|---|---|---|---|
| M01 | `mstore(base, 0)` after `mcopy(newBase, base, newBaseSize)` (uint256) | KILLED — `testSelfExtendUint256LeavesTheArrayUnmutated`, `…DoublesTheContents`, `…AllocatesExactly`, `…WritesNothingAboveFreeMemoryPointer` | SURVIVED (not this PR's target) | KILLED |
| M02 | inline `outputEnd := add(base, add(0x40, mul(totalLength, 0x20)))` — one word over-allocated (uint256) | KILLED — `testExtendInlineAllocatesExactly`, `testExtendAllocateAllocatesExactly`, `testSelfExtendUint256AllocatesExactly` | SURVIVED (not this PR's target) | KILLED |
| M03 | `if iszero(mload(base)) { baseAfter := extend leave }` (uint256) | killed ONLY by the fuzz test `testExtendInline(uint256[],uint256[])` drawing `args=[[], […]]` — chance, not coverage | KILLED — all four new uint256 tests | KILLED |
| M04 | `if and(iszero(mload(base)), iszero(mload(extend))) { baseAfter := base leave }` (uint256) | **SURVIVED** the whole 349-test suite | KILLED — `testExtendAllocateBothEmptyAllocatesFreshRegion` | KILLED |
| M05 | M03 for `bytes32` | killed only by the `bytes32` fuzz test, same chance draw | KILLED — all four new bytes32 tests | KILLED |
| M06 | M04 for `bytes32` | **SURVIVED** the whole 349-test suite | KILLED — `testExtendAllocateBothEmptyAllocatesFreshRegion` | KILLED |

The middle column is a separate probe run whose suite is
`forge test --match-test 'EmptyBase|BothEmpty'` — 8 tests, tally proven by the
probe's baseline (`baseline: green (8 passed)`), so the kills are attributable to
the new tests alone and not to a zero-match filter.

M03/M05 are the point of the issue in miniature: the mutant returns the extend
array itself when the base is empty, which is contents-identical and dies only if
a fuzz draw happens to contain an empty array. M04/M06 survive even that, because
both-empty is a draw the fuzzer never made.
