### PR TITLE
Test the documented pointer wrap and pin unsafeWriteWord's write extent

### DIFF
--- a/test/src/lib/LibPointer.t.sol
+++ b/test/src/lib/LibPointer.t.sol
@@ -11,6 +11,34 @@ contract LibPointerTest is Test {
     using LibPointer for Pointer;
     using LibBytes for bytes;
 
+    /// `unsafeWriteWord` writes the 32 bytes at the pointer and nothing else.
+    /// Claims three words, fills them with the complement of `word` so a stray
+    /// write can never be mistaken for the fill, then writes the middle word.
+    function checkWriteWordExtent(bytes32 word) internal pure {
+        uint256 low = Pointer.unwrap(LibPointer.allocatedMemoryPointer());
+        uint256 mid = low + 0x20;
+        uint256 high = low + 0x40;
+        bytes32 fill = ~word;
+        bytes32 lowAfter;
+        bytes32 midAfter;
+        bytes32 highAfter;
+        assembly ("memory-safe") {
+            mstore(0x40, add(low, 0x60))
+            mstore(low, fill)
+            mstore(mid, fill)
+            mstore(high, fill)
+        }
+        Pointer.wrap(mid).unsafeWriteWord(word);
+        assembly ("memory-safe") {
+            lowAfter := mload(low)
+            midAfter := mload(mid)
+            highAfter := mload(high)
+        }
+        assertEq(midAfter, word, "write missed the pointer");
+        assertEq(lowAfter, fill, "write touched the word below");
+        assertEq(highAfter, fill, "write touched the word above");
+    }
+
     function testUnsafeAsBytesRoundBytes(bytes memory data) public pure {
         assertEq(data, data.startPointer().unsafeAsBytes());
     }
@@ -19,28 +47,73 @@ contract LibPointerTest is Test {
         assertEq(Pointer.unwrap(pointer), Pointer.unwrap(pointer.unsafeAsBytes().startPointer()));
     }
 
-    function testUnsafeAddBytes(uint32 pointer, uint32 n) public pure {
-        assertEq(uint256(pointer) + uint256(n), Pointer.unwrap(Pointer.wrap(pointer).unsafeAddBytes(n)));
+    function testUnsafeAddBytes(uint256 pointer, uint256 n) public pure {
+        unchecked {
+            assertEq(pointer + n, Pointer.unwrap(Pointer.wrap(pointer).unsafeAddBytes(n)));
+        }
     }
 
-    function testUnsafeAddWord(uint32 pointer) public pure {
-        assertEq(uint256(pointer) + 0x20, Pointer.unwrap(Pointer.wrap(pointer).unsafeAddWord()));
+    /// The pointer wraps mod 2**256 and the whole offset counts.
+    function testUnsafeAddBytesWrap() public pure {
+        assertEq(0, Pointer.unwrap(Pointer.wrap(type(uint256).max).unsafeAddBytes(1)));
+        assertEq(0, Pointer.unwrap(Pointer.wrap(1).unsafeAddBytes(type(uint256).max)));
+        assertEq(
+            type(uint256).max - 1, Pointer.unwrap(Pointer.wrap(type(uint256).max).unsafeAddBytes(type(uint256).max))
+        );
     }
 
-    function testUnsafeAddWords(uint32 pointer, uint32 n) public pure {
-        assertEq(uint256(pointer) + uint256(n) * 0x20, Pointer.unwrap(Pointer.wrap(pointer).unsafeAddWords(n)));
+    function testUnsafeAddWord(uint256 pointer) public pure {
+        unchecked {
+            assertEq(pointer + 0x20, Pointer.unwrap(Pointer.wrap(pointer).unsafeAddWord()));
+        }
     }
 
-    function testUnsafeSubWord(uint32 pointer) public pure {
-        // The caller MUST ensure the pointer will not underflow on sub.
-        vm.assume(pointer >= 0x20);
-        assertEq(uint256(pointer) - 0x20, Pointer.unwrap(Pointer.wrap(pointer).unsafeSubWord()));
+    function testUnsafeAddWordWrap() public pure {
+        assertEq(0, Pointer.unwrap(Pointer.wrap(type(uint256).max - 0x1f).unsafeAddWord()));
+        assertEq(0x1f, Pointer.unwrap(Pointer.wrap(type(uint256).max).unsafeAddWord()));
     }
 
-    function testUnsafeSubWords(uint32 pointer, uint32 n) public pure {
-        // The caller MUST ensure the pointer will not underflow on sub.
-        vm.assume(uint256(pointer) >= uint256(n) * 0x20);
-        assertEq(uint256(pointer) - uint256(n) * 0x20, Pointer.unwrap(Pointer.wrap(pointer).unsafeSubWords(n)));
+    function testUnsafeAddWords(uint256 pointer, uint32 n) public pure {
+        unchecked {
+            assertEq(pointer + uint256(n) * 0x20, Pointer.unwrap(Pointer.wrap(pointer).unsafeAddWords(n)));
+        }
+    }
+
+    /// The word count keeps its full width, and the product of a real count
+    /// with `0x20` is what moves the pointer, wrapping mod 2**256.
+    function testUnsafeAddWordsWrap() public pure {
+        assertEq(0x1f, Pointer.unwrap(Pointer.wrap(type(uint256).max).unsafeAddWords(1)));
+        assertEq(0, Pointer.unwrap(Pointer.wrap(type(uint256).max - 0x3f).unsafeAddWords(2)));
+        assertEq(0x20 * (2 ** 32 + 1), Pointer.unwrap(Pointer.wrap(0).unsafeAddWords(2 ** 32 + 1)));
+    }
+
+    function testUnsafeSubWord(uint256 pointer) public pure {
+        unchecked {
+            assertEq(pointer - 0x20, Pointer.unwrap(Pointer.wrap(pointer).unsafeSubWord()));
+        }
+    }
+
+    function testUnsafeSubWordWrap() public pure {
+        assertEq(0, Pointer.unwrap(Pointer.wrap(0x20).unsafeSubWord()));
+        assertEq(type(uint256).max, Pointer.unwrap(Pointer.wrap(0x1f).unsafeSubWord()));
+        assertEq(type(uint256).max - 0x1f, Pointer.unwrap(Pointer.wrap(0).unsafeSubWord()));
+    }
+
+    function testUnsafeSubWords(uint256 pointer, uint32 n) public pure {
+        unchecked {
+            assertEq(pointer - uint256(n) * 0x20, Pointer.unwrap(Pointer.wrap(pointer).unsafeSubWords(n)));
+        }
+    }
+
+    /// The word count keeps its full width, and the product of a real count
+    /// with `0x20` is what moves the pointer, wrapping below zero.
+    function testUnsafeSubWordsWrap() public pure {
+        unchecked {
+            assertEq(0, Pointer.unwrap(Pointer.wrap(0x40).unsafeSubWords(2)));
+            assertEq(type(uint256).max - 0x1f, Pointer.unwrap(Pointer.wrap(0).unsafeSubWords(1)));
+            assertEq(type(uint256).max - 0x20, Pointer.unwrap(Pointer.wrap(0x1f).unsafeSubWords(2)));
+            assertEq(uint256(0) - 0x20 * (2 ** 32 + 1), Pointer.unwrap(Pointer.wrap(0).unsafeSubWords(2 ** 32 + 1)));
+        }
     }
 
     function testReadWriteRound(bytes32 a, bytes32 b) public pure {
@@ -49,6 +122,14 @@ contract LibPointerTest is Test {
         assertEq(a, pointer.unsafeReadWord());
         pointer.unsafeWriteWord(b);
         assertEq(b, pointer.unsafeReadWord());
+    }
+
+    function testUnsafeWriteWordExtent(bytes32 word) public pure {
+        checkWriteWordExtent(word);
+    }
+
+    function testUnsafeWriteWordExtentZero() public pure {
+        checkWriteWordExtent(bytes32(0));
     }
 
     function testAllocatedMemoryPointer(uint8 length_) public pure {


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.solmem/issues/70

## Verified against main first

Both gaps are live on `9a238f4`. `src/lib/LibPointer.sol` and `test/src/lib/LibPointer.t.sol` have not changed since the soldeer migration, and every mutant in the table below survives the unmodified suite: 33 suites, 349 tests, 0 failed, on each mutated run.

- Every movement test bounds the pointer to `uint32`, and the two `sub` tests `vm.assume` the underflow away, so the wrap the NatSpec documents ("can silently overflow" / "can silently underflow") is unreachable, boundaries `pointer == 0x20` and `pointer == 0` included.
- Nothing pins `unsafeWriteWord`'s write extent. `testReadWriteRound` writes and reads one pointer with no canary on either neighbour, and every other caller reads back only words it wrote itself.

One detail of the issue is stale: `src/lib/LibStackPointer.sol` no longer exists on main, so the "backs `LibStackPointer` pushes" framing is gone. The coverage gap it describes is not.

## Changed

`test/src/lib/LibPointer.t.sol` only. No source change.

- The five movement fuzz tests take a full `uint256` pointer and compare against an `unchecked` Solidity reference, so the wrap sits inside the fuzzed domain instead of outside it. `unsafeSubWord`/`unsafeSubWords` lose their `vm.assume`.
- Exact tests pin each wrap boundary, `unsafeSubWord` at `0x20`, `0x1f` and `0`.
- `unsafeAddWords`/`unsafeSubWords` keep a `uint32` word count in the fuzz and real counts in the exact tests, so `mul(0x20, words)` never wraps: what is under test is the pointer `add`/`sub`.
- `checkWriteWordExtent` claims three words, fills them with the complement of the word under test (so a stray write of that word can never be mistaken for the fill), writes the middle one, and asserts both neighbours still hold the fill.

## QA
- Discriminating tests: `testUnsafeAddBytesWrap`, `testUnsafeAddWordWrap`, `testUnsafeAddWordsWrap`, `testUnsafeSubWordWrap`, `testUnsafeSubWordsWrap`, `testUnsafeWriteWordExtent`, `testUnsafeWriteWordExtentZero`, and the five widened movement fuzz tests - each fails on base only under the mutation it targets; all seven mutants below pass the base suite untouched (verified per mutant, full suite, 349/349 green), and each is killed after this change (356 tests, 2 failed - 1 for M3).
- Mutations applied:

| # | `src/lib/LibPointer.sol` line | mutation | before | after (killing test) |
|---|---|---|---|---|
| M1 | `unsafeAddBytes`: `add(pointer, length)` | `add(pointer, and(length, 0xffffffff))` | SURVIVED | KILLED - `testUnsafeAddBytesWrap`, `testUnsafeAddBytes(uint256,uint256)` |
| M2 | `unsafeAddWord`: `add(pointer, 0x20)` | `mul(add(pointer, 0x20), gt(add(pointer, 0x20), pointer))` (saturate on overflow) | SURVIVED | KILLED - `testUnsafeAddWordWrap`, `testUnsafeAddWord(uint256)` |
| M3 | `unsafeAddWords`: `add(pointer, mul(0x20, words))` | `add(pointer, mul(0x20, and(words, 0xffffffff)))` | SURVIVED | KILLED - `testUnsafeAddWordsWrap` |
| M4 | `unsafeSubWord`: `sub(pointer, 0x20)` | `mul(sub(pointer, 0x20), gt(pointer, 0x1f))` (saturate at zero) | SURVIVED | KILLED - `testUnsafeSubWordWrap`, `testUnsafeSubWord(uint256)` |
| M5 | `unsafeSubWords`: `sub(pointer, mul(0x20, words))` | saturate at zero on underflow | SURVIVED | KILLED - `testUnsafeSubWordsWrap`, `testUnsafeSubWords(uint256,uint32)` |
| M6 | `unsafeWriteWord`: `mstore(pointer, word)` | plus `mstore(add(pointer, 0x20), word)` | SURVIVED | KILLED - `testUnsafeWriteWordExtent`, `testUnsafeWriteWordExtentZero` ("write touched the word above") |
| M7 | `unsafeWriteWord`: `mstore(pointer, word)` | plus `mstore(sub(pointer, 0x20), word)` | SURVIVED | KILLED - `testUnsafeWriteWordExtent`, `testUnsafeWriteWordExtentZero` ("write touched the word below") |

  Each row is a full `nix develop -c forge test` run whose summary line was read, so a mutant that failed to compile or a filter that matched nothing cannot pass as a survivor.
- Oracle: the expected pointer is `unchecked` Solidity arithmetic on `uint256`, computed in the test independently of the Yul under test, plus hand-computed constants at the wrap boundaries (`type(uint256).max + 1 == 0`, `0x1f - 0x20 == type(uint256).max`). The write-extent oracle is the EVM memory layout: exactly the 32 bytes at the pointer change, its neighbours keep a fill that cannot collide with the written word.
- Category check: issue asks (a) exercise the documented wrap on the movement functions, (b) pin `unsafeWriteWord`'s write extent. Covered a for all five movement functions (the issue proved two survivors, `unsafeAddBytes` and `unsafeSubWord`; the other three are the same category and were also surviving), and b in both directions, above and below the pointer. The read side is excluded, as the issue notes: mutants there are already killed.
