### PR TITLE
Name unsafeExtend's parameters as they are declared, and stop calling bytes32 an integer

### DIFF
--- a/src/lib/LibBytes32Array.sol
+++ b/src/lib/LibBytes32Array.sol
@@ -57,7 +57,7 @@ library LibBytes32Array {
 
     /// Building arrays from literal components is a common task that introduces
     /// boilerplate that is either inefficient or error prone.
-    /// @param a A single integer to build an array around.
+    /// @param a A single value to build an array around.
     /// @return array The newly allocated array including `a` as a single item.
     function arrayFrom(bytes32 a) internal pure returns (bytes32[] memory array) {
         assembly ("memory-safe") {
@@ -70,8 +70,8 @@ library LibBytes32Array {
 
     /// Building arrays from literal components is a common task that introduces
     /// boilerplate that is either inefficient or error prone.
-    /// @param a The first integer to build an array around.
-    /// @param b The second integer to build an array around.
+    /// @param a The first value to build an array around.
+    /// @param b The second value to build an array around.
     /// @return array The newly allocated array including `a` and `b` as the only
     /// items.
     function arrayFrom(bytes32 a, bytes32 b) internal pure returns (bytes32[] memory array) {
@@ -86,9 +86,9 @@ library LibBytes32Array {
 
     /// Building arrays from literal components is a common task that introduces
     /// boilerplate that is either inefficient or error prone.
-    /// @param a The first integer to build an array around.
-    /// @param b The second integer to build an array around.
-    /// @param c The third integer to build an array around.
+    /// @param a The first value to build an array around.
+    /// @param b The second value to build an array around.
+    /// @param c The third value to build an array around.
     /// @return array The newly allocated array including `a`, `b` and `c` as the
     /// only items.
     function arrayFrom(bytes32 a, bytes32 b, bytes32 c) internal pure returns (bytes32[] memory array) {
@@ -104,10 +104,10 @@ library LibBytes32Array {
 
     /// Building arrays from literal components is a common task that introduces
     /// boilerplate that is either inefficient or error prone.
-    /// @param a The first integer to build an array around.
-    /// @param b The second integer to build an array around.
-    /// @param c The third integer to build an array around.
-    /// @param d The fourth integer to build an array around.
+    /// @param a The first value to build an array around.
+    /// @param b The second value to build an array around.
+    /// @param c The third value to build an array around.
+    /// @param d The fourth value to build an array around.
     /// @return array The newly allocated array including `a`, `b`, `c` and `d` as the
     /// only items.
     function arrayFrom(bytes32 a, bytes32 b, bytes32 c, bytes32 d) internal pure returns (bytes32[] memory array) {
@@ -124,11 +124,11 @@ library LibBytes32Array {
 
     /// Building arrays from literal components is a common task that introduces
     /// boilerplate that is either inefficient or error prone.
-    /// @param a The first integer to build an array around.
-    /// @param b The second integer to build an array around.
-    /// @param c The third integer to build an array around.
-    /// @param d The fourth integer to build an array around.
-    /// @param e The fifth integer to build an array around.
+    /// @param a The first value to build an array around.
+    /// @param b The second value to build an array around.
+    /// @param c The third value to build an array around.
+    /// @param d The fourth value to build an array around.
+    /// @param e The fifth value to build an array around.
     /// @return array The newly allocated array including `a`, `b`, `c`, `d` and
     /// `e` as the only items.
     function arrayFrom(bytes32 a, bytes32 b, bytes32 c, bytes32 d, bytes32 e)
@@ -150,12 +150,12 @@ library LibBytes32Array {
 
     /// Building arrays from literal components is a common task that introduces
     /// boilerplate that is either inefficient or error prone.
-    /// @param a The first integer to build an array around.
-    /// @param b The second integer to build an array around.
-    /// @param c The third integer to build an array around.
-    /// @param d The fourth integer to build an array around.
-    /// @param e The fifth integer to build an array around.
-    /// @param f The sixth integer to build an array around.
+    /// @param a The first value to build an array around.
+    /// @param b The second value to build an array around.
+    /// @param c The third value to build an array around.
+    /// @param d The fourth value to build an array around.
+    /// @param e The fifth value to build an array around.
+    /// @param f The sixth value to build an array around.
     /// @return array The newly allocated array including `a`, `b`, `c`, `d`, `e`
     /// and `f` as the only items.
     function arrayFrom(bytes32 a, bytes32 b, bytes32 c, bytes32 d, bytes32 e, bytes32 f)
@@ -178,13 +178,13 @@ library LibBytes32Array {
 
     /// Building arrays from literal components is a common task that introduces
     /// boilerplate that is either inefficient or error prone.
-    /// @param a The first integer to build an array around.
-    /// @param b The second integer to build an array around.
-    /// @param c The third integer to build an array around.
-    /// @param d The fourth integer to build an array around.
-    /// @param e The fifth integer to build an array around.
-    /// @param f The sixth integer to build an array around.
-    /// @param g The seventh integer to build an array around.
+    /// @param a The first value to build an array around.
+    /// @param b The second value to build an array around.
+    /// @param c The third value to build an array around.
+    /// @param d The fourth value to build an array around.
+    /// @param e The fifth value to build an array around.
+    /// @param f The sixth value to build an array around.
+    /// @param g The seventh value to build an array around.
     /// @return array The newly allocated array including `a`, `b`, `c`, `d`, `e`,
     /// `f` and `g` as the only items.
     function arrayFrom(bytes32 a, bytes32 b, bytes32 c, bytes32 d, bytes32 e, bytes32 f, bytes32 g)
@@ -208,14 +208,14 @@ library LibBytes32Array {
 
     /// Building arrays from literal components is a common task that introduces
     /// boilerplate that is either inefficient or error prone.
-    /// @param a The first integer to build an array around.
-    /// @param b The second integer to build an array around.
-    /// @param c The third integer to build an array around.
-    /// @param d The fourth integer to build an array around.
-    /// @param e The fifth integer to build an array around.
-    /// @param f The sixth integer to build an array around.
-    /// @param g The seventh integer to build an array around.
-    /// @param h The eighth integer to build an array around.
+    /// @param a The first value to build an array around.
+    /// @param b The second value to build an array around.
+    /// @param c The third value to build an array around.
+    /// @param d The fourth value to build an array around.
+    /// @param e The fifth value to build an array around.
+    /// @param f The sixth value to build an array around.
+    /// @param g The seventh value to build an array around.
+    /// @param h The eighth value to build an array around.
     /// @return array The newly allocated array including `a`, `b`, `c`, `d`, `e`,
     /// `f`, `g` and `h` as the only items.
     function arrayFrom(bytes32 a, bytes32 b, bytes32 c, bytes32 d, bytes32 e, bytes32 f, bytes32 g, bytes32 h)
@@ -299,17 +299,16 @@ library LibBytes32Array {
         }
     }
 
-    /// Extends `base_` with `extend_` by allocating only an additional
-    /// `extend_.length` words onto `base_` and copying only `extend_` if
-    /// possible. If `base_` is large this MAY be significantly more efficient
-    /// than allocating `base_.length + extend_.length` for an entirely new array
-    /// and copying both `base_` and `extend_` into the new array one item at a
-    /// time in Solidity.
+    /// Extends `b` with `e` by allocating only an additional `e.length` words
+    /// onto `b` and copying only `e` if possible. If `b` is large this MAY be
+    /// significantly more efficient than allocating `b.length + e.length` for
+    /// an entirely new array and copying both `b` and `e` into the new array
+    /// one item at a time in Solidity.
     ///
     /// The efficient version of extension is only possible if the free memory
     /// pointer sits at the end of the base array at the moment of extension. If
     /// there is allocated memory after the end of base then extension will
-    /// require copying both the base and extend arays to a new region of memory.
+    /// require copying both the base and extend arrays to a new region of memory.
     /// The caller is responsible for optimising code paths to avoid additional
     /// allocations.
     ///
@@ -328,8 +327,8 @@ library LibBytes32Array {
     /// Both arrays MUST be valid solidity memory arrays, each owning the region
     /// its own length word describes.
     ///
-    /// @param b The base integer array that will be extended by `e`.
-    /// @param e The extend integer array that extends `b`.
+    /// @param b The base array that will be extended by `e`.
+    /// @param e The extend array that extends `b`.
     /// @return extended The extended array of `b` extended by `e`.
     function unsafeExtend(bytes32[] memory b, bytes32[] memory e) internal pure returns (bytes32[] memory extended) {
         assembly ("memory-safe") {

--- a/src/lib/LibUint256Array.sol
+++ b/src/lib/LibUint256Array.sol
@@ -299,17 +299,16 @@ library LibUint256Array {
         }
     }
 
-    /// Extends `base_` with `extend_` by allocating only an additional
-    /// `extend_.length` words onto `base_` and copying only `extend_` if
-    /// possible. If `base_` is large this MAY be significantly more efficient
-    /// than allocating `base_.length + extend_.length` for an entirely new array
-    /// and copying both `base_` and `extend_` into the new array one item at a
-    /// time in Solidity.
+    /// Extends `b` with `e` by allocating only an additional `e.length` words
+    /// onto `b` and copying only `e` if possible. If `b` is large this MAY be
+    /// significantly more efficient than allocating `b.length + e.length` for
+    /// an entirely new array and copying both `b` and `e` into the new array
+    /// one item at a time in Solidity.
     ///
     /// The efficient version of extension is only possible if the free memory
     /// pointer sits at the end of the base array at the moment of extension. If
     /// there is allocated memory after the end of base then extension will
-    /// require copying both the base and extend arays to a new region of memory.
+    /// require copying both the base and extend arrays to a new region of memory.
     /// The caller is responsible for optimising code paths to avoid additional
     /// allocations.
     ///


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.solmem/issues/84

## Verified against main

All three claims still hold on main (`9a238f4`), at line numbers shifted +6 from the issue:

| Claim | Check | Result on main |
| --- | --- | --- |
| `unsafeExtend` prose names `base_`/`extend_`, which do not exist | `grep -rn 'base_\|extend_' src/` | 10 hits, all doc lines: `LibUint256Array.sol:302-306` and `LibBytes32Array.sol:302-306`. No such identifier is declared anywhere. |
| `LibBytes32Array` documents every `bytes32` as an integer | `grep -c integer src/lib/LibBytes32Array.sol` | 38 |
| `arays` typo | `grep -rn arays src/` | 2 hits, `:312` in both files |

The signature is `unsafeExtend(uint256[] memory b, uint256[] memory e)` and the `@param` tags already say `b`/`e`, so the doc block named its own parameters two ways; the Yul body used a third pair, `base`/`extend`.

## The issue's alternative fix does not compile

The issue floated renaming the Solidity parameters to `base`/`extend` to match the Yul, calling it costlier but cleaner. It is not available. The Yul `extendInline(base, extend)` parameters would be shadowed by Solidity locals of the same name, and solc rejects every use of them in the body:

```
Error (6578): Cannot access local Solidity variables from inside an inline assembly function.
   --> src/lib/LibUint256Array.sol:372:28:
    |
372 |                     mstore(base, totalLength)
    |                            ^^^^
```

Six such errors. Making it compile means renaming the Yul parameters too, which discards the only thing the rename was for. Restating the prose in `b`/`e` is the whole fix available.

## What changed

Comments only, 102 changed lines, every one a `///` line:

```
$ git diff origin/main -U0 | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' | grep -vE '^[+-][[:space:]]*///' | wc -l
0
```

- Both `unsafeExtend` doc blocks: first paragraph restated in `b` and `e`.
- Both: `arays` -> `arrays`.
- `LibBytes32Array`: all 38 `integer`s gone. The 34 `arrayFrom` `@param`s become "value"; the two `unsafeExtend` `@param`s become "The base array" / "The extend array". `LibUint256Array` keeps "integer" — accurate for `uint256`.

No test is added: the rulings in force forbid tests that read or assert prose, and a comment change has nothing else to assert.

## Adversarial mutation pass

This diff changes no behaviour, so the honest table has two parts: proof the mutable set is empty, and control mutants proving the instruments that establish that are not blind.

**Proof the diff is behaviour-inert.** Built `main` and this branch with `FOUNDRY_BYTECODE_HASH=none FOUNDRY_CBOR_METADATA=false` so the metadata source hash cannot mask a real difference, then hashed the `"object"` fields of every artifact:

```
$ find out -name '*.json' -not -path 'out/build-info/*' | sort | while read f; do
    echo "$f $(grep -o '"object": *"0x[0-9a-f]*"' "$f" | sha256sum | cut -d' ' -f1)"; done
$ diff main.objects branch.objects
IDENTICAL: all 70 artifacts match
```

**Control mutants** — the same harness, the same build flags, against real behaviour, to show a difference would in fact show up. Baseline first, then the mutant, so a zero-match filter cannot be mistaken for a survivor.

| # | Mutation | Baseline | Mutant | Killed by | Bytecode |
| --- | --- | --- | --- | --- | --- |
| M1 | `LibUint256Array.sol:369` `totalLength := add(baseLength, extendLength)` -> `add(baseLength, add(extendLength, 1))` | 5 passed | **5 failed** | `testExtendInline`, `testExtendAllocate`, `testExtendAllocateDebug`, `testExtendAllocateEmptyExtendMovesBasePointer`, `testExtendInlineEmptyExtendKeepsBasePointer` | `LibUint256ArrayExtendTest` object `886c0399…` -> `a740ce7d…`, length 28550 -> 28562 |
| M2 | `LibBytes32Array.sol:369` same mutation | 5 passed | **5 failed** | the five `LibBytes32ArrayExtendTest` tests | — |
| M3 | `LibBytes32Array.sol:65` `mstore(array, 1)` -> `mstore(array, 2)` in `arrayFrom(bytes32)` | 30 passed | **1 failed** of 30 | `testArrayFromA(bytes32)`, `192 != 224` | — |

M1 and M2 run 5 tests both before and after; M3 runs 30 both before and after. The suites ran.

Whole suite on this branch: `33 test suites, 349 tests passed, 0 failed, 0 skipped`.

## QA
- Discriminating tests: n/a - comment-only diff, and the rulings in force forbid tests that read or assert prose. The three control mutants below were killed by existing tests: `testExtendInline`, `testExtendAllocate`, `testExtendAllocateDebug`, `testExtendAllocateEmptyExtendMovesBasePointer`, `testExtendInlineEmptyExtendKeepsBasePointer` (both array libs) and `testArrayFromA(bytes32)`.
- Mutations applied: M1 `LibUint256Array.sol:369` `add(baseLength, extendLength)` -> `add(baseLength, add(extendLength, 1))` -> killed by all 5 `LibUint256ArrayExtendTest` tests; M2 same at `LibBytes32Array.sol:369` -> killed by all 5 `LibBytes32ArrayExtendTest` tests; M3 `LibBytes32Array.sol:65` `mstore(array, 1)` -> `mstore(array, 2)` -> killed by `testArrayFromA(bytes32)`. The diff itself has no mutable line: all 102 changed lines are `///` comments and all 70 build artifacts hash identically to main with metadata disabled.
- Oracle: the issue's own claims, each re-derived from main by grep before changing anything (`base_`/`extend_` = 10 hits and 0 declarations; `integer` = 38 in `LibBytes32Array.sol`; `arays` = 2). The corrected prose is checked against the declared signature `unsafeExtend(uint256[] memory b, uint256[] memory e)` and the `@param` tags, not against the old prose. The rename alternative was checked against solc, which rejects it.
- Category check: issue asks (A) `unsafeExtend` prose names nonexistent `base_`/`extend_`, (B) `LibBytes32Array` documents `bytes32` as an integer, (C) `arays` typo; covered A, B, C in both files. Category swept beyond the named lines: `grep -rnE '///.*[a-zA-Z0-9]_\b' src/` = 0 phantom underscore identifiers repo-wide, every `@param` in `src/` cross-checked against its signature (scanner validated on a planted `@param zzz`, which it caught), and `integer` appears in no other `bytes32` file.
