### PR TITLE
Record the commits Protofire reviewed in audit/audits.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,14 +70,19 @@ silent pointer wraparound, and aliasing.
 
 ## Audit
 
-Protofire reviewed `src/` in January 2026. The report is in
-[`audit/protofire/`](audit/protofire/); the commits it reviewed and the files it
-covered are in [`audit/audits.json`](audit/audits.json).
+Protofire reviewed rain.solmem in January 2026. The
+[report](audit/protofire/rain.solmem.228b35c6725877e7fbcd2432b4c692357f16f510.jan-2026.pdf)
+covers two reviews — `228b35c6` on the 13th and `26bce619` on the 26th, the
+latter being the end of the audited tree. Scope was the twelve contracts listed
+in [`audit/audits.json`](audit/audits.json), which were all of `src/` at those
+commits.
 
-`src/` has moved since. To see by how much:
+`src/` today is not that tree: some of the audited files have since been
+deleted, and some of what is there now the audit never saw. To see how far it
+has moved:
 
 ```sh
-git diff --stat <reviewed-commit>..HEAD -- src/
+git diff --stat 26bce6197383f193e35326bab4d4424cf6eafde7..HEAD -- src/
 ```
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@ bounds access, double-frees, and aliasing are the caller's responsibility.
   compile time; cancun bytecode on a chain without cancun reverts with
   `invalid opcode` at runtime.
 
+## Audit
+
+Protofire reviewed `src/` in January 2026. The report is in
+[`audit/protofire/`](audit/protofire/); the commits it reviewed and the files it
+covered are in [`audit/audits.json`](audit/audits.json).
+
+`src/` has moved since. To see by how much:
+
+```sh
+git diff --stat <reviewed-commit>..HEAD -- src/
+```
+
 ## Install
 
 Via [soldeer](https://soldeer.xyz) (in your foundry project's root):

--- a/audit/audits.json
+++ b/audit/audits.json
@@ -1,0 +1,24 @@
+[
+  {
+    "auditor": "Protofire",
+    "report": "audit/protofire/rain.solmem.228b35c6725877e7fbcd2432b4c692357f16f510.jan-2026.pdf",
+    "reviews": [
+      { "date": "2026-01-13", "commit": "228b35c6725877e7fbcd2432b4c692357f16f510" },
+      { "date": "2026-01-26", "commit": "26bce6197383f193e35326bab4d4424cf6eafde7" }
+    ],
+    "scope": [
+      "src/error/ErrBytes.sol",
+      "src/error/ErrStackPointer.sol",
+      "src/error/ErrUint256Array.sol",
+      "src/lib/LibBytes.sol",
+      "src/lib/LibBytes32Array.sol",
+      "src/lib/LibBytes32Matrix.sol",
+      "src/lib/LibMemCpy.sol",
+      "src/lib/LibPointer.sol",
+      "src/lib/LibStackPointer.sol",
+      "src/lib/LibStackSentinel.sol",
+      "src/lib/LibUint256Array.sol",
+      "src/lib/LibUint256Matrix.sol"
+    ]
+  }
+]


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.solmem/issues/88

## Verified against main (`9a238f4`)

The premise holds, and the numbers in the issue are stale in the direction that makes it worse.

| Claim in #88 | On main today |
| --- | --- |
| the audited commit is encoded only in the PDF filename | still true — grepping `protofire` over every tracked file on main, the PDF itself excluded, returns zero hits |
| README never mentions the audit | still true |
| `228b35c6` is an ancestor of HEAD | yes |
| 74 commits behind | **142** |
| 5 of 9 libraries changed | **8 of the 12 audited sources changed**, and `src/lib/LibStackPointer.sol` has been deleted outright |

The issue also gets the audited commit half wrong, which the fix had to correct. The report's own Reviews table lists **two** reviews, not one:

| Date | Commit |
| --- | --- |
| 13/01/26 | `228b35c6725877e7fbcd2432b4c692357f16f510` |
| 26/01/26 | `26bce6197383f193e35326bab4d4424cf6eafde7` |

`26bce619` is the re-review after M01/L01/I01 were fixed — at `43222a6`, `96955a1` and `9b0de96`, all present and all ancestors of HEAD — and is the real end of the audited tree. Recording only `228b35c6`, as the issue proposed, would have understated the audited surface by 11 commits and left the three fix commits looking unreviewed.

Scope is the report's own explicit twelve-file contract list, not the issue's `src/**/*.sol` glob. A glob is wrong today: it resolves to eleven files at HEAD, silently absorbing sources the audit never saw and silently dropping the deleted `LibStackPointer.sol`, so it would describe a scope the audit never had.

## Changed

- `audit/audits.json` — auditor, report path, both review commits with their dates, and the twelve in-scope sources.
- `README.md` — an `## Audit` section. It is the first link to the report from anywhere in the repo. It names the audited scope, links the report PDF directly, and pins the drift baseline to `26bce619` (see [CodeRabbit review](#coderabbit-review) below).

No Solidity changed. Latest run at `e36fae2` — `nix develop -c forge test`: 389 passed, 0 failed, across 35 suites. `nix develop -c reuse lint`: compliant, 69/69 files — `audit/**/` in `REUSE.toml` already covers the new file.

## Not in this PR

The issue's third part, a non-blocking CI drift report, is not here. This repo's CI is two `uses:` lines into `rainix-sol.yaml`; there is no step to add without putting shared CI in a consumer. The drift computation also needs `fetch-depth: 0`, which the rainix reusable's checkout controls. Filed as https://github.com/rainlanguage/rainix/issues/321, with the manifest format and the two other repos whose audit filenames encode a tag or a bare date rather than a commit.

## Adversarial mutation pass

No behaviour changed, so there is no Solidity mutant to raise. What this PR adds is a set of factual claims, so those are what I mutated — against the checks https://github.com/rainlanguage/rainix/issues/321 will run.

Baseline: **27 checks, 27 pass, 0 fail** — 1 report path, plus 2 commits x (1 ancestry check + 12 scope paths).

| # | Mutation | Checks run | Result |
| --- | --- | --- | --- |
| M1 | `reviews[0].commit` last hex digit `0` to `1` | 15 | **killed** — `commit not in history: …f16f511` |
| M2 | `reviews[1].commit` to a real commit object off every branch | 27 | **killed** — `commit not an ancestor of HEAD`, plus its 12 scope lookups |
| M3 | `scope` gains `test/src/lib/LibMatrix.flattenWrap.t.sol`, which exists at HEAD but at neither review | 29 | **killed** — absent at both `228b35c6` and `26bce619` |
| M4 | `report` to `audit/protofire/nope.pdf` | 27 | **killed** — `report missing` |
| M5 | `scope` drops `src/lib/LibStackPointer.sol` | 25 | **SURVIVED** |

The check count moves with every mutation — 15 / 27 / 29 / 27 / 25 against a baseline of 27 — so the checks ran rather than matching nothing.

**M5 is a real, disclosed gap.** Narrowing `scope` leaves every surviving entry valid, so no ancestry or presence check can see it, and the manifest would quietly claim the audit never covered a file it did cover. `LibStackPointer.sol` is exactly the entry at risk, because it no longer exists at HEAD and dropping it would look like tidying. Only a human diffing the manifest against the PDF catches this, and https://github.com/rainlanguage/rainix/issues/321 says so rather than implying the check is total.

## QA
- Discriminating tests: n/a as forge tests — the change adds no Solidity, and the standing ruling is not to bind docs or metadata with a test. The discriminating checks are the four in the mutation table: report-path existence, commit resolution, ancestry, and per-commit scope-path presence. Each fails on a mutated manifest and passes on the committed one, and the checks are proven to have run by the differing counts, 15/27/29/27/25 against a baseline of 27.
- Mutations applied: `reviews[0].commit` last hex digit 0 to 1 -> killed by the commit-resolution check; `reviews[1].commit` to a real commit object off every branch -> killed by the ancestry check; `scope` gains `test/src/lib/LibMatrix.flattenWrap.t.sol` -> killed by the scope-presence check at both reviews; `report` to `audit/protofire/nope.pdf` -> killed by the report-path check; `scope` drops `src/lib/LibStackPointer.sol` -> SURVIVED, disclosed above as a gap no ancestry or presence check can close.
- Oracle: the Protofire PDF, read independently of the issue. Its Reviews table supplies both commits and their dates; its Scope table supplies the twelve contracts. Git supplies ancestry and drift. The issue text was not used as the oracle, and was wrong on three counts — one review commit rather than two, 74 commits behind rather than 142, and a `src/**/*.sol` glob rather than the report's explicit file list.
- Category check: the issue asks for A, a machine-readable audited commit; B, a non-blocking CI drift report; C, a README reference. A and C are covered here. B is deliberately not covered in this repo — shared CI lives in rainix reusables, and the drift computation needs `fetch-depth: 0` from the reusable's checkout — and is filed as https://github.com/rainlanguage/rainix/issues/321.

## One consequence worth naming

`.soldeerignore` excludes `/audit`, so the manifest and the PDF do not ship in the soldeer package, and the two new README links are repo-relative only. The README already links `.github/workflows/publish-soldeer.yaml` the same way, so this follows the existing convention rather than breaking it; shipping the audit trail inside the package is a separate decision I have not made here.

The PDF's document metadata title reads `Report_rain.solmem_2.0_jan_2025`. Its cover, its Reviews table and both commit dates all say January 2026, so the manifest records 2026 and the metadata is a stale template field.

## After merging main in

Main has moved twice while this was open, so it is merged in twice: at `21c0ac7`, which took main to `7620643` (`0.1.17`), and again at `e17ed4a`, which took it to `b74081b` (`0.1.22`) and brought in `#138` through `#144`. Full suite at `e36fae2`: 389 passed, 0 failed, 35 suites. `reuse lint`: compliant, 69/69.

The manifest re-verifies unchanged at each merge — 27 checks, 27 pass. Nothing in it is HEAD-relative: the scope-presence checks resolve at the two review commits, so main deleting an audited file cannot invalidate the record, which is the point of recording it.

Drift has grown each time. At `9a238f4` the table above recorded `228b35c6` 142 commits behind and 8 of 12 audited sources changed. At `e36fae2` it is:

| | At `9a238f4` | At `21c0ac7` | At `e36fae2` |
| --- | --- | --- | --- |
| `228b35c6` behind | 142 | 151 | **188** |
| `26bce619` behind | 131 | 140 | **177** |
| audited sources changed | 8 of 12 | 9 of 12 | **11 of 12** |
| audited sources deleted | 1 | 1 | **3** |

Only `src/lib/LibPointer.sol` is still byte-identical to the audited tree. The second merge brought in `#140` (`f6443d0`), which deleted `src/error/ErrBytes.sol` and `src/error/ErrUint256Array.sol` — joining the already-deleted `src/lib/LibStackPointer.sol` — and added `src/error/ErrTruncate.sol` and `src/error/ErrStackSentinel.sol`, which the audit never saw. This is the drift the README section now warns about in words rather than leaving to the reader.

## CodeRabbit review

Two inline findings on `README.md`, both judged against the manifest, the PDF and the tree. Both applied; the wording of the first diverges from the proposal, and the reason is on the [thread](https://github.com/rainlanguage/rain.solmem/pull/137#discussion_r3804193063).

**1. Align the README with the audit manifest.** Applied in substance: the section now states the scope and links the report PDF itself rather than the `audit/protofire/` directory.

Not applied as worded. The finding says the prose "can imply that all of `src/` was audited"; all of `src/` *was* audited. At both reviewed commits `src/` was exactly the twelve contracts in the manifest — `git ls-tree -r --name-only <commit> -- src/` diffs empty against `jq -r '.[0].scope[]'` at `228b35c6` and again at `26bce619`, and both match the PDF's Scope table. The proposed "the twelve files listed in `audit/audits.json`" drops that. The real defect is tense, not coverage, so the section says the twelve were all of `src/` **at those commits** and then says outright that today's `src/` is not that tree.

**2. Use the latest audited commit as the diff baseline.** Applied — `<reviewed-commit>` is now `26bce6197383f193e35326bab4d4424cf6eafde7`, the later review and a descendant of `228b35c6` by 11 commits, so the end of the audited tree. Same reasoning this PR already gives for recording both commits.

Its committable suggestion was not applied, and could not be: it does not match its own proposed diff. It replaces lines 36-40 with only the prose line above the fence, which would delete the ```sh block and the command the finding is about. The proposed diff was applied instead. Noted on the [thread](https://github.com/rainlanguage/rain.solmem/pull/137#discussion_r3804196068).

## One thing this PR does not fix

The `## Errors` table on `main` cites `src/error/ErrBytes.sol` and `src/error/ErrUint256Array.sol` for `TruncateError` and `OutOfBoundsTruncate`. Both files were deleted by `#140`, which consolidated them into `src/error/ErrTruncate.sol`. That staleness is on `main` and predates this branch — `git show main:README.md` has it — so it is not this PR's to fix and merging this does not make it worse. Worth its own issue.

## M5 closed for this manifest, not for future edits

The committed `scope` was checked against the report mechanically, not by eye: `pdftotext -f 3 -l 4` over the PDF's Scope table, `grep -oE 'src/[A-Za-z0-9_/]+\.sol'`, sorted and `diff`ed against `jq -r '.[0].scope[]'`. 12 lines each side, empty diff. So the M5 mutant is a gap in the standing check, not an open question about what is in this file today — but the next edit to `scope` gets no such guarantee, which is why https://github.com/rainlanguage/rainix/issues/321 states the limit rather than hiding it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an Audit section documenting the January 2026 review, including the report, reviewed files, and source comparison command.
  * Added a record of the audit scope and reviewed revisions for reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
