### PR TITLE
Serialise Package Release runs per ref

### DIFF
--- a/.github/workflows/package-release.yaml
+++ b/.github/workflows/package-release.yaml
@@ -1,4 +1,9 @@
 name: Package Release
+# One release run at a time per ref. A run mid-publish is never cancelled; a
+# pending run is superseded by a newer one.
+concurrency:
+  group: package-release-${{ github.ref }}
+  cancel-in-progress: false
 on:
   push:
     branches:


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.solmem/issues/89

## Verified against main

`.github/workflows/package-release.yaml` at main (`9a238f4`) still has no `concurrency:` block, so every push to `main` starts an independent Package Release run.

The issue was filed as LOW/theoretical. It is neither — the race has fired twice in this repo since, both on 2026-08-17:

| when (UTC) | runs started | outcome |
|---|---|---|
| 05:39:19 / 05:39:23 / 05:39:27 | 3 runs in 8s (merges of #113, #101, #100) | #101 published `0.1.10`. [#113's run](https://github.com/rainlanguage/rain.solmem/actions/runs/31998658964) died `Failed to run soldeer: error during publishing: dependency already exists`. [#100's run](https://github.com/rainlanguage/rain.solmem/actions/runs/31998666592) died `foundry.toml [package].version (0.1.10) is not ahead of the published revision (0.1.10)` |
| 06:01:06 / 06:01:10 | 2 runs in 4s (merges of #103, #112) | #103 published `0.1.11`. [#112's run](https://github.com/rainlanguage/rain.solmem/actions/runs/31999962131) died `dependency already exists` |

Both losers read the same `[package].version` as the winner before the winner published. The wedge the issue describes (winner publishes, then loses the `Tag and push` rebase race, leaving `main` declaring an already-published version) did not land on those two occasions, but nothing prevents it: `Tag and push` fetches, rebases and pushes with no retry, and `rainix-static soldeer-gate` hard-errors on a `[package].version` that is not strictly ahead of the registry, which blocks every subsequent release until someone hand-bumps `foundry.toml`.

## Changed

```yaml
 name: Package Release
+# One release run at a time per ref. A run mid-publish is never cancelled; a
+# pending run is superseded by a newer one.
+concurrency:
+  group: package-release-${{ github.ref }}
+  cancel-in-progress: false
 on:
```

`cancel-in-progress: false` keeps a half-finished publish from being killed; a newer pending run supersedes an older pending one, so a burst of merges collapses to the newest content rather than queueing a stale run per merge. The group is a literal, not `${{ github.workflow }}` — a called workflow inherits the caller's workflow name, so that expression would collide with any group the reusable later defines.

Placement: the caller is where the `on:` trigger lives and is the one lever this repo has today. The equivalent for the other ten consumers of `rainix-autopublish.yaml`, none of which have a concurrency group either, is filed at https://github.com/rainlanguage/rainix/issues/324. A literal group name here does not collide with one added there.

## Mutation pass

No Solidity changed, so the forge suite is not the oracle for this diff — `actionlint` is. Baseline: `nix run nixpkgs#actionlint -- .github/workflows/package-release.yaml` exits 0 clean on the branch. Each mutant was written over the file, linted, and the file restored.

| # | mutant | actionlint | result |
|---|---|---|---|
| M1 | drop the `concurrency:` block (revert to main) | exit 0, silent | **SURVIVED** |
| M2 | `cancel-in-progress: false` → `true` | exit 0, silent | **SURVIVED** |
| M3 | `cancel-in-progress:` → `cancel-in-progres:` | `unexpected key "cancel-in-progres" for "concurrency" section` | KILLED |
| M4 | drop `group:` | `group name is missing in "concurrency" section` | KILLED |
| M5 | `${{ github.ref }}` → `${{ needs.release.outputs.v }}` | `context "needs" is not allowed here. available contexts are "github", "inputs", "vars"` | KILLED |

M5 doubles as the proof that `github.ref` is legal in a workflow-level `concurrency.group`.

M1 and M2 are the two semantically load-bearing mutants and both survive: nothing in this repo, and nothing in `rainix-sol.yaml`, lints workflow files at all (`actionlint` appears nowhere in rainix). Killing them needs a workflow lint in shared CI, not a forge test in `test/src/**` — no test here can read `.github/`, and one that did would be asserting config rather than behaviour. Recorded as a gap, not papered over.

## Suite

`nix develop -c bash -c 'forge soldeer install && forge fmt --check && forge test'` → exit 0. 33 suites, **349 tests passed, 0 failed, 0 skipped**. Unchanged by this diff, which touches no Solidity.

## QA
- Discriminating tests: n/a as forge tests — the diff is GitHub Actions config, no Solidity changed, so nothing under `test/src/**` can observe it. The oracle that does discriminate is `nix run nixpkgs#actionlint -- .github/workflows/package-release.yaml`: exit 0 on this branch, exit 1 on M3/M4/M5 below. `forge fmt --check && forge test` is reported as an unchanged-baseline check (33 suites, 349 passed, 0 failed), not as coverage of this diff.
- Mutations applied: `cancel-in-progress: false` -> `true` (SURVIVED); whole `concurrency:` block deleted, i.e. revert to main (SURVIVED); `cancel-in-progress:` -> `cancel-in-progres:` (KILLED by actionlint, `unexpected key ... expected one of "cancel-in-progress", "group"`); `group:` line deleted (KILLED by actionlint, `group name is missing in "concurrency" section`); `${{ github.ref }}` -> `${{ needs.release.outputs.v }}` (KILLED by actionlint, `context "needs" is not allowed here`). 3 killed, 2 survived; both survivors are named above with why no in-repo oracle can kill them.
- Oracle: GitHub Actions workflow syntax as encoded by actionlint, independent of this repo; plus the five real Package Release runs of 2026-08-17 linked above, which are observed behaviour rather than a spec reading.
- Category check: issue asks for a `concurrency` group on the release workflow with `cancel-in-progress: false`; covered exactly that, with a literal group name rather than `${{ github.workflow }}`. The issue's second-order claims (the wedge mechanism in `Tag and push`, and the stale-checkout follower) are stated above as still unguarded and filed against rainix rather than worked around here.

## QA
- Discriminating tests: `nix develop -c reuse lint` - fails on this branch with `"CHANGELOG.md"` removed from `REUSE.toml` (exit 1, 66/67 files licensed) and passes with it present (exit 0, 67/67). No Solidity test was added: the diff touches no `src/**` or `test/**`, and a test asserting a doc's prose is out of bounds.
- Mutations applied: `REUSE.toml` `path` list -> delete `"CHANGELOG.md",` -> killed by `reuse lint` (the CI legal job), exit 0 -> 1, licensed-file count 67 -> 66. Baseline committed at `8b254aa` before mutating; `REUSE.toml` restored and re-checked (`grep -c CHANGELOG REUSE.toml` = 1).
- Oracle: the per-version entries are derived from `git diff sol-v<n-1>..sol-v<n> -- src/ README.md`, i.e. the shipped surface as the tags actually record it, not from PR titles or issue text. That oracle is what caught the issue's own off-by-one (#57 shipped in `0.1.4`, not `0.1.5`). Package membership is checked against `forge soldeer push --dry-run`'s zip, not against reading `.soldeerignore`.
- Category check: issue asks (1) a changelog that ships and is surfaced in the release, (2) make the bump level expressible, (3) gate the publish on CI. Covered (1)'s artifact half here. (1)'s release-surfacing half -> https://github.com/rainlanguage/rainix/issues/323 and (3) -> https://github.com/rainlanguage/rainix/issues/322, both because they are edits to rainix's shared reusable workflow and composite, which every Soldeer consumer shares. (2) is not covered because it is already true on main: the published version is `[package].version` from the committed `foundry.toml`, settable to any semver level by the PR that needs it.
