### PR TITLE
One truncation error for bytes and both array libs

### DIFF
--- a/src/error/ErrBytes.sol
+++ b/src/error/ErrBytes.sol
@@ -1,8 +1,0 @@
-// SPDX-License-Identifier: LicenseRef-DCL-1.0
-// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
-pragma solidity ^0.8.25;
-
-/// Thrown when asked to truncate data to a longer length.
-/// @param length Actual bytes length.
-/// @param truncate Attempted truncation length.
-error TruncateError(uint256 length, uint256 truncate);

--- a/src/error/ErrStackSentinel.sol
+++ b/src/error/ErrStackSentinel.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity ^0.8.25;
+
+import {Pointer} from "../lib/LibPointer.sol";
+import {Sentinel} from "../lib/LibStackSentinel.sol";
+
+/// Thrown when the sentinel tuple size is zero.
+error ZeroSentinelTupleSize();
+
+/// Thrown when the sentinel cannot be found. This can be because the sentinel
+/// was not in the stack, but also if the sentinel is in the stack but not
+/// aligned with the tuples size, or if the scan stepped outside the stack
+/// bounds and only found a sentinel valued word out there, which is not the
+/// caller's sentinel.
+/// @param sentinel The sentinel that was not found.
+error MissingSentinel(Sentinel sentinel);
+
+/// Thrown when the stack bounds are invalid because the lower is above the
+/// upper.
+/// @param lower The lower stack pointer.
+/// @param upper The upper stack pointer.
+error InvalidStackBounds(Pointer lower, Pointer upper);
+
+/// Thrown when the top of the stack is above the allocated memory pointer, so
+/// the tuples array cannot be built without overwriting the stack it describes.
+/// @param upper The upper stack pointer.
+/// @param allocated The allocated memory pointer.
+error UnallocatedStack(Pointer upper, Pointer allocated);

--- a/src/error/ErrTruncate.sol
+++ b/src/error/ErrTruncate.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity ^0.8.25;
+
+/// Thrown if a truncated length is longer than the data being truncated. It is
+/// not possible to truncate something and increase its length as the memory
+/// region after it MAY be allocated for something else already. Thrown by
+/// `LibBytes`, `LibUint256Array` and `LibBytes32Array` alike.
+/// @param currentLength The current length of the data.
+/// @param truncatedLength The requested, longer, length.
+error OutOfBoundsTruncate(uint256 currentLength, uint256 truncatedLength);

--- a/src/error/ErrUint256Array.sol
+++ b/src/error/ErrUint256Array.sol
@@ -1,8 +1,0 @@
-// SPDX-License-Identifier: LicenseRef-DCL-1.0
-// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
-pragma solidity ^0.8.25;
-
-/// Thrown if a truncated length is longer than the array being truncated. It is
-/// not possible to truncate something and increase its length as the memory
-/// region after the array MAY be allocated for something else already.
-error OutOfBoundsTruncate(uint256 arrayLength, uint256 truncatedLength);

--- a/src/lib/LibBytes.sol
+++ b/src/lib/LibBytes.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.25;
 
 import {Pointer} from "./LibPointer.sol";
-import {TruncateError} from "../error/ErrBytes.sol";
+import {OutOfBoundsTruncate} from "../error/ErrTruncate.sol";
 
 /// @title LibBytes
 /// @notice Tools for working directly with memory in a Solidity compatible way.
@@ -12,7 +12,7 @@ library LibBytes {
     /// Any excess bytes are leaked
     function truncate(bytes memory data, uint256 length) internal pure {
         if (data.length < length) {
-            revert TruncateError(data.length, length);
+            revert OutOfBoundsTruncate(data.length, length);
         }
         assembly ("memory-safe") {
             mstore(data, length)

--- a/src/lib/LibBytes32Array.sol
+++ b/src/lib/LibBytes32Array.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.25;
 
 import {Pointer} from "./LibPointer.sol";
-import {OutOfBoundsTruncate} from "../error/ErrUint256Array.sol";
+import {OutOfBoundsTruncate} from "../error/ErrTruncate.sol";
 
 /// @title Bytes32Array
 /// @notice Things we want to do carefully and efficiently with bytes32 arrays

--- a/src/lib/LibStackSentinel.sol
+++ b/src/lib/LibStackSentinel.sol
@@ -4,29 +4,12 @@ pragma solidity ^0.8.25;
 
 import {LibPointer, Pointer} from "./LibPointer.sol";
 import {UnalignedStackPointer} from "../error/ErrStackPointer.sol";
-
-/// Thrown when the sentinel tuple size is zero.
-error ZeroSentinelTupleSize();
-
-/// Thrown when the sentinel cannot be found. This can be because the sentinel
-/// was not in the stack, but also if the sentinel is in the stack but not
-/// aligned with the tuples size, or if the scan stepped outside the stack
-/// bounds and only found a sentinel valued word out there, which is not the
-/// caller's sentinel.
-/// @param sentinel The sentinel that was not found.
-error MissingSentinel(Sentinel sentinel);
-
-/// Thrown when the stack bounds are invalid because the lower is above the
-/// upper.
-/// @param lower The lower stack pointer.
-/// @param upper The upper stack pointer.
-error InvalidStackBounds(Pointer lower, Pointer upper);
-
-/// Thrown when the top of the stack is above the allocated memory pointer, so
-/// the tuples array cannot be built without overwriting the stack it describes.
-/// @param upper The upper stack pointer.
-/// @param allocated The allocated memory pointer.
-error UnallocatedStack(Pointer upper, Pointer allocated);
+import {
+    InvalidStackBounds,
+    MissingSentinel,
+    UnallocatedStack,
+    ZeroSentinelTupleSize
+} from "../error/ErrStackSentinel.sol";
 
 /// > In computer programming, a sentinel value (also referred to as a flag
 /// > value, trip value, rogue value, signal value, or dummy data)[1] is a

--- a/src/lib/LibUint256Array.sol
+++ b/src/lib/LibUint256Array.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.25;
 
 import {Pointer} from "./LibPointer.sol";
-import {OutOfBoundsTruncate} from "../error/ErrUint256Array.sol";
+import {OutOfBoundsTruncate} from "../error/ErrTruncate.sol";
 
 /// @title Uint256Array
 /// @notice Things we want to do carefully and efficiently with uint256 arrays

--- a/test/src/error/ErrTruncate.t.sol
+++ b/test/src/error/ErrTruncate.t.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {OutOfBoundsTruncate} from "src/error/ErrTruncate.sol";
+import {LibBytes} from "src/lib/LibBytes.sol";
+import {LibBytes32Array} from "src/lib/LibBytes32Array.sol";
+import {LibUint256Array} from "src/lib/LibUint256Array.sol";
+
+contract ErrTruncateTest is Test {
+    function truncateBytesExternal(uint256 length, uint256 truncatedLength) external pure {
+        LibBytes.truncate(new bytes(length), truncatedLength);
+    }
+
+    function truncateUint256ArrayExternal(uint256 length, uint256 truncatedLength) external pure {
+        LibUint256Array.truncate(new uint256[](length), truncatedLength);
+    }
+
+    function truncateBytes32ArrayExternal(uint256 length, uint256 truncatedLength) external pure {
+        LibBytes32Array.truncate(new bytes32[](length), truncatedLength);
+    }
+
+    /// `bytes`, `uint256[]` and `bytes32[]` all report an over long truncation
+    /// with byte identical revert data, so one selector and one parameter order
+    /// covers every truncation in the library.
+    function testEveryTruncationRevertsIdentically(uint8 length, uint8 excess) public view {
+        uint256 truncatedLength = uint256(length) + uint256(excess) + 1;
+        bytes memory expected = abi.encodeWithSelector(OutOfBoundsTruncate.selector, length, truncatedLength);
+
+        (bool bytesSuccess, bytes memory bytesData) =
+            address(this).staticcall(abi.encodeCall(this.truncateBytesExternal, (length, truncatedLength)));
+        (bool uint256ArraySuccess, bytes memory uint256ArrayData) =
+            address(this).staticcall(abi.encodeCall(this.truncateUint256ArrayExternal, (length, truncatedLength)));
+        (bool bytes32ArraySuccess, bytes memory bytes32ArrayData) =
+            address(this).staticcall(abi.encodeCall(this.truncateBytes32ArrayExternal, (length, truncatedLength)));
+
+        assertFalse(bytesSuccess, "bytes");
+        assertFalse(uint256ArraySuccess, "uint256[]");
+        assertFalse(bytes32ArraySuccess, "bytes32[]");
+
+        assertEq(bytesData, expected, "bytes revert data");
+        assertEq(uint256ArrayData, expected, "uint256[] revert data");
+        assertEq(bytes32ArrayData, expected, "bytes32[] revert data");
+    }
+}

--- a/test/src/lib/LibBytes.t.sol
+++ b/test/src/lib/LibBytes.t.sol
@@ -3,7 +3,8 @@
 pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
-import {LibBytes, TruncateError} from "src/lib/LibBytes.sol";
+import {LibBytes} from "src/lib/LibBytes.sol";
+import {OutOfBoundsTruncate} from "src/error/ErrTruncate.sol";
 import {LibPointer, Pointer, LibMemCpy} from "src/lib/LibMemCpy.sol";
 
 contract LibBytesTest is Test {
@@ -23,7 +24,7 @@ contract LibBytesTest is Test {
 
     function testTruncateError(bytes memory data, uint256 length) public {
         vm.assume(data.length < length);
-        vm.expectRevert(abi.encodeWithSelector(TruncateError.selector, data.length, length));
+        vm.expectRevert(abi.encodeWithSelector(OutOfBoundsTruncate.selector, data.length, length));
         this.truncateExternal(data, length);
     }
 
@@ -133,7 +134,7 @@ contract LibBytesTest is Test {
     /// Truncating to one byte longer than the current length reverts.
     function testTruncateOneTooLongExact() public {
         bytes memory data = hex"0102030405";
-        vm.expectRevert(abi.encodeWithSelector(TruncateError.selector, 5, 6));
+        vm.expectRevert(abi.encodeWithSelector(OutOfBoundsTruncate.selector, 5, 6));
         this.truncateExternal(data, 6);
     }
 }

--- a/test/src/lib/LibBytes32Array.truncate.t.sol
+++ b/test/src/lib/LibBytes32Array.truncate.t.sol
@@ -5,7 +5,7 @@ pragma solidity =0.8.25;
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibBytes32Array, Pointer} from "src/lib/LibBytes32Array.sol";
 import {LibPointer} from "src/lib/LibPointer.sol";
-import {OutOfBoundsTruncate} from "src/error/ErrUint256Array.sol";
+import {OutOfBoundsTruncate} from "src/error/ErrTruncate.sol";
 import {LibBytes32ArraySlow} from "test/lib/LibBytes32ArraySlow.sol";
 
 contract LibBytes32ArrayTruncateTest is Test {

--- a/test/src/lib/LibStackSentinel.t.sol
+++ b/test/src/lib/LibStackSentinel.t.sol
@@ -8,13 +8,12 @@ import {LibPointer, Pointer} from "src/lib/LibPointer.sol";
 import {LibUint256Array} from "src/lib/LibUint256Array.sol";
 import {UnalignedStackPointer} from "src/error/ErrStackPointer.sol";
 import {
-    LibStackSentinel,
-    Sentinel,
-    MissingSentinel,
-    ZeroSentinelTupleSize,
     InvalidStackBounds,
-    UnallocatedStack
-} from "src/lib/LibStackSentinel.sol";
+    MissingSentinel,
+    UnallocatedStack,
+    ZeroSentinelTupleSize
+} from "src/error/ErrStackSentinel.sol";
+import {LibStackSentinel, Sentinel} from "src/lib/LibStackSentinel.sol";
 
 contract LibStackSentinelTest is Test {
     using LibUint256Array for uint256[];

--- a/test/src/lib/LibUint256Array.truncate.t.sol
+++ b/test/src/lib/LibUint256Array.truncate.t.sol
@@ -5,7 +5,7 @@ pragma solidity =0.8.25;
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibUint256Array, Pointer} from "src/lib/LibUint256Array.sol";
 import {LibPointer} from "src/lib/LibPointer.sol";
-import {OutOfBoundsTruncate} from "src/error/ErrUint256Array.sol";
+import {OutOfBoundsTruncate} from "src/error/ErrTruncate.sol";
 import {LibUint256ArraySlow} from "test/lib/LibUint256ArraySlow.sol";
 
 contract LibUint256ArrayTruncateTest is Test {


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.solmem/issues/85

## Verified against main (`9a238f4`)

The finding is live on main, nothing pre-fixed:

- `src/error/ErrBytes.sol:8` declared `error TruncateError(uint256 length, uint256 truncate)`, thrown at `src/lib/LibBytes.sol:15`.
- `src/error/ErrUint256Array.sol:8` declared `error OutOfBoundsTruncate(uint256 arrayLength, uint256 truncatedLength)`, imported by `src/lib/LibUint256Array.sol:6` **and** `src/lib/LibBytes32Array.sol:6`, and by `test/src/lib/LibBytes32Array.truncate.t.sol:8` — the `bytes32[]`-consumer-imports-a-uint256-named-file leak the issue names, still exactly as filed.
- `src/lib/LibStackSentinel.sol` still declared its errors inline.

Two things in the issue have moved or were wrong:

- The sentinel errors are now **four**, not three. `UnalignedStackPointer` has since moved out to `src/error/ErrStackPointer.sol`, and a fourth inline error, `UnallocatedStack`, has been added. All four inline ones move here.
- Option (b) changes **one** selector, not two. `OutOfBoundsTruncate(uint256,uint256)` = `0x383f2cc8` is unaffected by renaming its parameters `arrayLength` -> `currentLength`; only `LibBytes` moves off `TruncateError(uint256,uint256)` = `0x1afc46fc`.
- `Sentinel` staying in `LibStackSentinel.sol` does not avoid an import cycle — `ErrStackSentinel.sol` has to import `Sentinel` back for `MissingSentinel`. solc 0.8.25 compiles the file-level cycle without complaint, because the definitions themselves are acyclic. The cycle is real and harmless, so `Sentinel` stays where it is.

Took option (b). One condition, one error.

## Changed

`src/error/ErrTruncate.sol` (renamed from `ErrUint256Array.sol`) holds the single `OutOfBoundsTruncate(uint256 currentLength, uint256 truncatedLength)` for `bytes`, `uint256[]` and `bytes32[]` alike. `src/error/ErrBytes.sol` and its `TruncateError` are deleted; `LibBytes.truncate` now reverts `OutOfBoundsTruncate` with the same two values in the same order it always used.

`src/error/ErrStackSentinel.sol` holds `ZeroSentinelTupleSize`, `MissingSentinel`, `InvalidStackBounds` and `UnallocatedStack`, moved verbatim out of `src/lib/LibStackSentinel.sol`. Selectors and parameter order unchanged, so this half is non-breaking.

`test/src/error/ErrTruncate.t.sol` is new and pins the point of the change: all three truncations produce **byte identical** revert data for the same over-long request, so a future `Bytes32OutOfBoundsTruncate` cannot be reintroduced quietly.

### Downstream break

`TruncateError` is gone. A consumer catching `bytes` truncation failures must switch to `OutOfBoundsTruncate` from `rain.solmem/error/ErrTruncate.sol`. Consumers importing `OutOfBoundsTruncate` from `rain.solmem/error/ErrUint256Array.sol` must repoint the path; the selector they decode is unchanged.

The selector change wants a minor bump, and autopublish can only emit a patch bump — that gap is https://github.com/rainlanguage/rain.solmem/issues/87, not this PR.

## Mutation pass

Baseline on the branch: **350 tests passed, 0 failed** across 34 suites. Every mutant below ran the **whole** suite (no `--match` filter, so no zero-match survivor), and every row reports the suite total so the run is provably real.

| # | Mutation | Whole-suite result | Killed by |
|---|---|---|---|
| M1 | `LibBytes.truncate` reverts a re-declared `TruncateError(uint256,uint256)` (`0x1afc46fc`) instead of the shared error | 347 passed / **3 failed** of 350 | `ErrTruncateTest.testEveryTruncationRevertsIdentically`, `LibBytesTest.testTruncateError`, `LibBytesTest.testTruncateOneTooLongExact` |
| M2 | `LibBytes.truncate` reverts `OutOfBoundsTruncate(length, data.length)` — parameters swapped | 347 / **3** of 350 | same three |
| M3 | `LibBytes.truncate` guard `data.length < length` → `data.length + 1 < length` | 347 / **3** of 350 | same three |
| M4 | `LibUint256Array.truncate` reverts `OutOfBoundsTruncate(newLength, array.length)` — parameters swapped | 346 / **4** of 350 | `ErrTruncateTest.testEveryTruncationRevertsIdentically`, `LibUint256ArrayTruncateTest.{testTruncateError, testTruncateOneTooLongReverts, testTruncateEmptyToOneReverts}` |
| M5 | `LibBytes32Array.truncate` reverts `OutOfBoundsTruncate(newLength, array.length)` — parameters swapped | 346 / **4** of 350 | `ErrTruncateTest.testEveryTruncationRevertsIdentically`, `LibBytes32ArrayTruncateTest.{testTruncateError, testTruncateOneTooLongReverts, testTruncateEmptyToOneReverts}` |
| M6 | `LibBytes32Array.truncate` declares and reverts its own `Bytes32OutOfBoundsTruncate` — exactly the re-fragmentation the issue predicts | 346 / **4** of 350 | same four as M5 |
| M7 | `InvalidStackBounds` declared and thrown as `(upper, lower)` after the move | 349 / **1** of 350 | `LibStackSentinelTest.testConsumeSentinelTuplesInvertedBoundsError` |
| M8 | `MissingSentinel(Sentinel.wrap(0))` instead of the sentinel actually asked for | 346 / **4** of 350 | `LibStackSentinelTest.{testConsumeSentinelTuplesMissingSentinel, testConsumeSentinelTuplesEmptyError, testConsumeSentinelTuplesOddSentinel, testConsumeSentinelTuplesUnallocatedMissingSentinel}` |
| M9 | `UnallocatedStack` declared and thrown as `(allocated, upper)` after the move | 349 / **1** of 350 | `LibStackSentinelTest.testConsumeSentinelTuplesUnallocatedStackError` |

One mutant was discarded rather than counted: dropping the parameter from `MissingSentinel` fails to compile on the `@param sentinel` NatSpec, so it never reached the tests and is neither a kill nor a survivor. M8 replaces it with a value mutation that does compile.

No survivors. Working tree verified clean against the committed branch after the last `git checkout`.

## QA

- Discriminating tests: `ErrTruncateTest.testEveryTruncationRevertsIdentically` is new and fails on base — on `main` `LibBytes` reverts `TruncateError` (`0x1afc46fc`) while the arrays revert `OutOfBoundsTruncate` (`0x383f2cc8`), so the byte-identical assertion cannot hold; verified by M1, which restores exactly that base behaviour and fails the test with `0x1afc46fc… != 0x383f2cc8…`. The existing `LibBytesTest.{testTruncateError, testTruncateOneTooLongExact}`, `LibUint256ArrayTruncateTest.{testTruncateError, testTruncateOneTooLongReverts, testTruncateEmptyToOneReverts}`, `LibBytes32ArrayTruncateTest.{…same…}` and `LibStackSentinelTest.{testConsumeSentinelTuplesInvertedBoundsError, testConsumeSentinelTuplesUnallocatedStackError, testConsumeSentinelTuplesMissingSentinel, testConsumeSentinelTuplesEmptyError, testConsumeSentinelTuplesOddSentinel, testConsumeSentinelTuplesUnallocatedMissingSentinel}` are repointed at the moved declarations, not rewritten, and are shown below to still discriminate.
- Mutations applied: the M1–M9 table above. Every row is a whole-suite run (no `--match` filter), every row reports `N passed / M failed of 350`, and every row has M ≥ 1. Nine mutants, nine kills, zero survivors.
- Oracle: the revert condition and its two operands are derived from `truncate`'s own contract — a request to grow rather than shrink is rejected, reporting (current length, requested length) in that order — not from either implementation. `testEveryTruncationRevertsIdentically` builds the expected 68 bytes with `abi.encodeWithSelector` from `length` and `length + excess + 1`, and compares raw `staticcall` returndata across all three libraries, so no library is checked against another library's output.
- Category check: issue asks (a) end the two-spellings/one-condition split, (b) end the `bytes32[]`-consumer-imports-`ErrUint256Array` misdirection, (c) move `LibStackSentinel`'s inline errors under `src/error/`. Covered a, b, c. (c) is four errors, not the three the issue lists, because `UnallocatedStack` was added after filing — the category is "every error `LibStackSentinel` declares inline", so all four moved.
