### PR TITLE
README: publishing is merge-driven, and the version is the next one

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,21 @@ Use the nix-pinned `forge` for all development to keep versions consistent.
 
 ## Publish
 
-Tag `v<x.y.z>` on `main`. The
-[`Publish to Soldeer`](.github/workflows/publish-soldeer.yaml) workflow runs
-`forge soldeer push rain-solmem~<x.y.z>` on every `v*` tag. The package name is
-derived from the repo name with `.` substituted for `-`.
+Publishing is merge-driven; there is no release tag to push. On every push to
+`main`, [`Package Release`](.github/workflows/package-release.yaml) calls
+rainix's `rainix-autopublish`, which compares the package content against the
+latest published revision. If it differs, it runs
+`forge soldeer push rain-solmem~<version>`, tags `sol-v<version>`, and commits a
+bump of `[package] version` back to `main`.
+
+`[package] version` in `foundry.toml` is the **next, unpublished** version, not
+the current one. It is always one ahead of the registry; do not "correct" it to
+match.
+
+Everything [`.soldeerignore`](.soldeerignore) does not exclude ships — `src/**`,
+`README.md`, `LICENSE`, `LICENSES/`, `REUSE.toml` — and any change to it
+publishes a new revision, including a comment-only edit. Soldeer revisions are
+immutable and cannot be deleted.
 
 ## License
 


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.solmem/issues/98


## QA
- Discriminating tests: n/a - docs-only diff; this repo does not test prose (`c2a7cf5` stripped `test/PackageRequirements.t.sol` for exactly that).
- Mutations applied: n/a - no code changed, so there is no behaviour to mutate.
- Oracle: the artefacts the text describes, read directly - `.github/workflows/package-release.yaml` (trigger, hardcoded `soldeer-package`), rainix `rainix-autopublish.yaml` (content gate, `forge soldeer push`, `git tag sol-v<version>`, version bump commit), `git ls-files .github` (dead link), `git tag` (`sol-v0.1.4`..`sol-v0.1.16`), `api.soldeer.xyz/api/v1/revision?project_name=rain-solmem` (published `0.1.16` vs `foundry.toml` `0.1.17`), and the unpacked `0.1.16` zip (what ships).
- Category check: issue asks for (1) the dead workflow link, (2) the wrong trigger, (3) the tag format/direction, (4) the package-name derivation, (5) the undocumented next-version semantics of `[package].version`, (6) the merge-publishes-anything hazard - all six covered. The issue's seventh item, a README-path CI link check, is Refs-only: it is scoped to the nix-tasks issue it was proposed alongside.