### PR TITLE
Relative import paths in test/src/lib

### DIFF
--- a/test/src/error/ErrTruncate.t.sol
+++ b/test/src/error/ErrTruncate.t.sol
@@ -3,10 +3,10 @@
 pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
-import {OutOfBoundsTruncate} from "src/error/ErrTruncate.sol";
-import {LibBytes} from "src/lib/LibBytes.sol";
-import {LibBytes32Array} from "src/lib/LibBytes32Array.sol";
-import {LibUint256Array} from "src/lib/LibUint256Array.sol";
+import {OutOfBoundsTruncate} from "../../../src/error/ErrTruncate.sol";
+import {LibBytes} from "../../../src/lib/LibBytes.sol";
+import {LibBytes32Array} from "../../../src/lib/LibBytes32Array.sol";
+import {LibUint256Array} from "../../../src/lib/LibUint256Array.sol";
 
 contract ErrTruncateTest is Test {
     function truncateBytesExternal(uint256 length, uint256 truncatedLength) external pure {

--- a/test/src/lib/LibArray.aliasedTail.t.sol
+++ b/test/src/lib/LibArray.aliasedTail.t.sol
@@ -3,8 +3,8 @@
 pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
-import {LibUint256Array} from "src/lib/LibUint256Array.sol";
-import {LibBytes32Array} from "src/lib/LibBytes32Array.sol";
+import {LibUint256Array} from "../../../src/lib/LibUint256Array.sol";
+import {LibBytes32Array} from "../../../src/lib/LibBytes32Array.sol";
 
 /// The tail taking `arrayFrom` overloads allocate their output at the free
 /// memory pointer and read the tail's length word to size the copy. A tail that

--- a/test/src/lib/LibArray.selfExtend.t.sol
+++ b/test/src/lib/LibArray.selfExtend.t.sol
@@ -3,8 +3,8 @@
 pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
-import {LibUint256Array} from "src/lib/LibUint256Array.sol";
-import {LibBytes32Array} from "src/lib/LibBytes32Array.sol";
+import {LibUint256Array} from "../../../src/lib/LibUint256Array.sol";
+import {LibBytes32Array} from "../../../src/lib/LibBytes32Array.sol";
 
 /// Extending an array by itself. Base and extend are then ONE array, so the in
 /// place path would rewrite the length word both of them read through, mutating

--- a/test/src/lib/LibArraySlow.copySlow.t.sol
+++ b/test/src/lib/LibArraySlow.copySlow.t.sol
@@ -4,8 +4,8 @@ pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 
-import {LibUint256ArraySlow} from "test/lib/LibUint256ArraySlow.sol";
-import {LibBytes32ArraySlow} from "test/lib/LibBytes32ArraySlow.sol";
+import {LibUint256ArraySlow} from "../../lib/LibUint256ArraySlow.sol";
+import {LibBytes32ArraySlow} from "../../lib/LibBytes32ArraySlow.sol";
 
 /// `copySlow` snapshots an input before it is handed to an implementation under
 /// test, so the differential tests can build their expected values from memory

--- a/test/src/lib/LibBytes.t.sol
+++ b/test/src/lib/LibBytes.t.sol
@@ -3,8 +3,8 @@
 pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
-import {LibBytes, TruncateError} from "src/lib/LibBytes.sol";
-import {LibPointer, Pointer, LibMemCpy} from "src/lib/LibMemCpy.sol";
+import {LibBytes, TruncateError} from "../../../src/lib/LibBytes.sol";
+import {LibPointer, Pointer, LibMemCpy} from "../../../src/lib/LibMemCpy.sol";
 
 contract LibBytesTest is Test {
     using LibBytes for bytes;

--- a/test/src/lib/LibBytes32Array.allocation.t.sol
+++ b/test/src/lib/LibBytes32Array.allocation.t.sol
@@ -4,8 +4,8 @@ pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 
-import {LibBytes32Array, Pointer} from "src/lib/LibBytes32Array.sol";
-import {LibPointer} from "src/lib/LibPointer.sol";
+import {LibBytes32Array, Pointer} from "../../../src/lib/LibBytes32Array.sol";
+import {LibPointer} from "../../../src/lib/LibPointer.sol";
 
 /// The existing `unsafeExtend` tests assert the CONTENTS of the extended array
 /// against a reference implementation. Contents alone cannot see the allocator

--- a/test/src/lib/LibBytes32Array.arrayFrom.t.sol
+++ b/test/src/lib/LibBytes32Array.arrayFrom.t.sol
@@ -4,10 +4,10 @@ pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 
-import {LibBytes32Array, Pointer} from "src/lib/LibBytes32Array.sol";
-import {LibPointer} from "src/lib/LibPointer.sol";
+import {LibBytes32Array, Pointer} from "../../../src/lib/LibBytes32Array.sol";
+import {LibPointer} from "../../../src/lib/LibPointer.sol";
 
-import {LibBytes32ArraySlow} from "test/lib/LibBytes32ArraySlow.sol";
+import {LibBytes32ArraySlow} from "../../lib/LibBytes32ArraySlow.sol";
 
 contract LibBytes32ArrayArrayFromTest is Test {
     using LibBytes32Array for bytes32;

--- a/test/src/lib/LibBytes32Array.extend.t.sol
+++ b/test/src/lib/LibBytes32Array.extend.t.sol
@@ -4,8 +4,8 @@ pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 
-import {LibBytes32Array, Pointer} from "src/lib/LibBytes32Array.sol";
-import {LibBytes32ArraySlow} from "test/lib/LibBytes32ArraySlow.sol";
+import {LibBytes32Array, Pointer} from "../../../src/lib/LibBytes32Array.sol";
+import {LibBytes32ArraySlow} from "../../lib/LibBytes32ArraySlow.sol";
 
 contract LibBytes32ArrayExtendTest is Test {
     // This code path hits the inline extension by ensuring that c is the most

--- a/test/src/lib/LibBytes32Array.pointer.t.sol
+++ b/test/src/lib/LibBytes32Array.pointer.t.sol
@@ -3,7 +3,7 @@
 pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
-import {LibBytes32Array, Pointer} from "src/lib/LibBytes32Array.sol";
+import {LibBytes32Array, Pointer} from "../../../src/lib/LibBytes32Array.sol";
 
 contract LibBytes32ArrayPointerTest is Test {
     using LibBytes32Array for bytes32[];

--- a/test/src/lib/LibBytes32Array.reverse.t.sol
+++ b/test/src/lib/LibBytes32Array.reverse.t.sol
@@ -3,9 +3,9 @@
 pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
-import {LibBytes32Array, Pointer} from "src/lib/LibBytes32Array.sol";
-import {LibPointer} from "src/lib/LibPointer.sol";
-import {LibBytes32ArraySlow} from "test/lib/LibBytes32ArraySlow.sol";
+import {LibBytes32Array, Pointer} from "../../../src/lib/LibBytes32Array.sol";
+import {LibPointer} from "../../../src/lib/LibPointer.sol";
+import {LibBytes32ArraySlow} from "../../lib/LibBytes32ArraySlow.sol";
 
 contract LibBytes32ArrayReverseTest is Test {
     /// Test that the reverse function works as expected according to the

--- a/test/src/lib/LibBytes32Array.truncate.t.sol
+++ b/test/src/lib/LibBytes32Array.truncate.t.sol
@@ -3,10 +3,10 @@
 pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
-import {LibBytes32Array, Pointer} from "src/lib/LibBytes32Array.sol";
-import {LibPointer} from "src/lib/LibPointer.sol";
-import {OutOfBoundsTruncate} from "src/error/ErrUint256Array.sol";
-import {LibBytes32ArraySlow} from "test/lib/LibBytes32ArraySlow.sol";
+import {LibBytes32Array, Pointer} from "../../../src/lib/LibBytes32Array.sol";
+import {LibPointer} from "../../../src/lib/LibPointer.sol";
+import {OutOfBoundsTruncate} from "../../../src/error/ErrUint256Array.sol";
+import {LibBytes32ArraySlow} from "../../lib/LibBytes32ArraySlow.sol";
 
 contract LibBytes32ArrayTruncateTest is Test {
     function truncateExternal(bytes32[] memory a, uint256 newLength) external pure returns (bytes32[] memory) {

--- a/test/src/lib/LibBytes32Matrix.allocation.t.sol
+++ b/test/src/lib/LibBytes32Matrix.allocation.t.sol
@@ -4,8 +4,8 @@ pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 
-import {LibBytes32Array} from "src/lib/LibBytes32Array.sol";
-import {LibBytes32Matrix, LibPointer, Pointer} from "src/lib/LibBytes32Matrix.sol";
+import {LibBytes32Array} from "../../../src/lib/LibBytes32Array.sol";
+import {LibBytes32Matrix, LibPointer, Pointer} from "../../../src/lib/LibBytes32Matrix.sol";
 
 /// The existing `flatten` tests assert the CONTENTS of the flattened array.
 /// `flatten` also performs an allocation, and an over-allocating `flatten`

--- a/test/src/lib/LibBytes32Matrix.endPointer.t.sol
+++ b/test/src/lib/LibBytes32Matrix.endPointer.t.sol
@@ -4,8 +4,8 @@ pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 
-import {LibBytes32Array} from "src/lib/LibBytes32Array.sol";
-import {LibBytes32Matrix, LibPointer, Pointer} from "src/lib/LibBytes32Matrix.sol";
+import {LibBytes32Array} from "../../../src/lib/LibBytes32Array.sol";
+import {LibBytes32Matrix, LibPointer, Pointer} from "../../../src/lib/LibBytes32Matrix.sol";
 
 /// `endPointer` on a matrix is one word past the last REFERENCE, which is not
 /// the end of any allocation. The NatSpec on `endPointer` states where the inner

--- a/test/src/lib/LibBytes32Matrix.flatten.t.sol
+++ b/test/src/lib/LibBytes32Matrix.flatten.t.sol
@@ -3,8 +3,8 @@
 pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
-import {LibBytes32Matrix} from "src/lib/LibBytes32Matrix.sol";
-import {LibBytes32MatrixSlow} from "test/lib/LibBytes32MatrixSlow.sol";
+import {LibBytes32Matrix} from "../../../src/lib/LibBytes32Matrix.sol";
+import {LibBytes32MatrixSlow} from "../../lib/LibBytes32MatrixSlow.sol";
 
 contract LibBytes32MatrixFlattenTest is Test {
     using LibBytes32Matrix for bytes32[][];

--- a/test/src/lib/LibBytes32Matrix.itemCount.t.sol
+++ b/test/src/lib/LibBytes32Matrix.itemCount.t.sol
@@ -3,9 +3,9 @@
 pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
-import {LibBytes32Matrix} from "src/lib/LibBytes32Matrix.sol";
-import {LibPointer, Pointer} from "src/lib/LibPointer.sol";
-import {LibBytes32MatrixSlow} from "test/lib/LibBytes32MatrixSlow.sol";
+import {LibBytes32Matrix} from "../../../src/lib/LibBytes32Matrix.sol";
+import {LibPointer, Pointer} from "../../../src/lib/LibPointer.sol";
+import {LibBytes32MatrixSlow} from "../../lib/LibBytes32MatrixSlow.sol";
 
 contract LibBytes32MatrixItemCountTest is Test {
     using LibBytes32Matrix for bytes32[][];

--- a/test/src/lib/LibBytes32Matrix.matrixFrom.t.sol
+++ b/test/src/lib/LibBytes32Matrix.matrixFrom.t.sol
@@ -3,10 +3,10 @@
 pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
-import {LibBytes32Array} from "src/lib/LibBytes32Array.sol";
-import {LibBytes32Matrix, LibPointer, Pointer} from "src/lib/LibBytes32Matrix.sol";
+import {LibBytes32Array} from "../../../src/lib/LibBytes32Array.sol";
+import {LibBytes32Matrix, LibPointer, Pointer} from "../../../src/lib/LibBytes32Matrix.sol";
 
-import {LibBytes32MatrixSlow} from "test/lib/LibBytes32MatrixSlow.sol";
+import {LibBytes32MatrixSlow} from "../../lib/LibBytes32MatrixSlow.sol";
 
 contract LibBytes32ArrayMatrixFromTest is Test {
     using LibBytes32Array for bytes32;

--- a/test/src/lib/LibBytes32Matrix.pointer.t.sol
+++ b/test/src/lib/LibBytes32Matrix.pointer.t.sol
@@ -3,9 +3,9 @@
 pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
-import {LibBytes32Matrix, Pointer} from "src/lib/LibBytes32Matrix.sol";
+import {LibBytes32Matrix, Pointer} from "../../../src/lib/LibBytes32Matrix.sol";
 
-import {LibBytes32MatrixSlow} from "test/lib/LibBytes32MatrixSlow.sol";
+import {LibBytes32MatrixSlow} from "../../lib/LibBytes32MatrixSlow.sol";
 
 contract LibBytes32MatrixPointerTest is Test {
     using LibBytes32Matrix for bytes32[][];

--- a/test/src/lib/LibMatrix.flattenWrap.t.sol
+++ b/test/src/lib/LibMatrix.flattenWrap.t.sol
@@ -3,7 +3,7 @@
 pragma solidity =0.8.25;
 
 import {Test, stdError} from "forge-std-1.16.1/src/Test.sol";
-import {LibMatrixFlattenWrapHarness} from "test/src/lib/LibMatrixFlattenWrapHarness.sol";
+import {LibMatrixFlattenWrapHarness} from "./LibMatrixFlattenWrapHarness.sol";
 
 /// Reproduces issue #62 for `LibUint256Matrix` and its byte identical
 /// `LibBytes32Matrix` twin.

--- a/test/src/lib/LibMatrixFlattenWrapHarness.sol
+++ b/test/src/lib/LibMatrixFlattenWrapHarness.sol
@@ -2,8 +2,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {LibUint256Matrix} from "src/lib/LibUint256Matrix.sol";
-import {LibBytes32Matrix} from "src/lib/LibBytes32Matrix.sol";
+import {LibUint256Matrix} from "../../../src/lib/LibUint256Matrix.sol";
+import {LibBytes32Matrix} from "../../../src/lib/LibBytes32Matrix.sol";
 
 /// Harness for `itemCount` and `flatten` on both matrix libraries.
 ///

--- a/test/src/lib/LibMemCpy.Bytes.t.sol
+++ b/test/src/lib/LibMemCpy.Bytes.t.sol
@@ -4,9 +4,9 @@ pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 
-import {LibMemCpy} from "src/lib/LibMemCpy.sol";
-import {Pointer, LibBytes} from "src/lib/LibBytes.sol";
-import {LibPointer} from "src/lib/LibPointer.sol";
+import {LibMemCpy} from "../../../src/lib/LibMemCpy.sol";
+import {Pointer, LibBytes} from "../../../src/lib/LibBytes.sol";
+import {LibPointer} from "../../../src/lib/LibPointer.sol";
 
 contract LibMemCpyBytesTest is Test {
     using LibPointer for Pointer;

--- a/test/src/lib/LibMemCpy.Words.t.sol
+++ b/test/src/lib/LibMemCpy.Words.t.sol
@@ -4,9 +4,9 @@ pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 
-import {LibMemCpy} from "src/lib/LibMemCpy.sol";
-import {LibUint256Array, Pointer} from "src/lib/LibUint256Array.sol";
-import {LibPointer} from "src/lib/LibPointer.sol";
+import {LibMemCpy} from "../../../src/lib/LibMemCpy.sol";
+import {LibUint256Array, Pointer} from "../../../src/lib/LibUint256Array.sol";
+import {LibPointer} from "../../../src/lib/LibPointer.sol";
 
 contract LibMemCpyWordsTest is Test {
     using LibPointer for Pointer;

--- a/test/src/lib/LibPointer.t.sol
+++ b/test/src/lib/LibPointer.t.sol
@@ -4,8 +4,8 @@ pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 
-import {LibPointer, Pointer} from "src/lib/LibPointer.sol";
-import {LibBytes} from "src/lib/LibBytes.sol";
+import {LibPointer, Pointer} from "../../../src/lib/LibPointer.sol";
+import {LibBytes} from "../../../src/lib/LibBytes.sol";
 
 contract LibPointerTest is Test {
     using LibPointer for Pointer;

--- a/test/src/lib/LibStackSentinel.t.sol
+++ b/test/src/lib/LibStackSentinel.t.sol
@@ -4,9 +4,9 @@ pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 
-import {LibPointer, Pointer} from "src/lib/LibPointer.sol";
-import {LibUint256Array} from "src/lib/LibUint256Array.sol";
-import {UnalignedStackPointer} from "src/error/ErrStackPointer.sol";
+import {LibPointer, Pointer} from "../../../src/lib/LibPointer.sol";
+import {LibUint256Array} from "../../../src/lib/LibUint256Array.sol";
+import {UnalignedStackPointer} from "../../../src/error/ErrStackPointer.sol";
 import {
     LibStackSentinel,
     Sentinel,
@@ -14,7 +14,7 @@ import {
     ZeroSentinelTupleSize,
     InvalidStackBounds,
     UnallocatedStack
-} from "src/lib/LibStackSentinel.sol";
+} from "../../../src/lib/LibStackSentinel.sol";
 
 contract LibStackSentinelTest is Test {
     using LibUint256Array for uint256[];

--- a/test/src/lib/LibStackSentinel.tupleSizeWrap.t.sol
+++ b/test/src/lib/LibStackSentinel.tupleSizeWrap.t.sol
@@ -3,7 +3,7 @@
 pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
-import {LibStackSentinelWrapHarness} from "test/src/lib/LibStackSentinelWrapHarness.sol";
+import {LibStackSentinelWrapHarness} from "./LibStackSentinelWrapHarness.sol";
 
 /// Reproduces the `consumeSentinelTuples` half of issue #54.
 ///

--- a/test/src/lib/LibStackSentinelWrapHarness.sol
+++ b/test/src/lib/LibStackSentinelWrapHarness.sol
@@ -2,9 +2,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {LibStackSentinel, Sentinel} from "src/lib/LibStackSentinel.sol";
-import {LibUint256Array} from "src/lib/LibUint256Array.sol";
-import {Pointer} from "src/lib/LibPointer.sol";
+import {LibStackSentinel, Sentinel} from "../../../src/lib/LibStackSentinel.sol";
+import {LibUint256Array} from "../../../src/lib/LibUint256Array.sol";
+import {Pointer} from "../../../src/lib/LibPointer.sol";
 
 /// Harness for `LibStackSentinel.consumeSentinelTuples`.
 ///

--- a/test/src/lib/LibUint256Array.allocation.t.sol
+++ b/test/src/lib/LibUint256Array.allocation.t.sol
@@ -4,8 +4,8 @@ pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 
-import {LibUint256Array, Pointer} from "src/lib/LibUint256Array.sol";
-import {LibPointer} from "src/lib/LibPointer.sol";
+import {LibUint256Array, Pointer} from "../../../src/lib/LibUint256Array.sol";
+import {LibPointer} from "../../../src/lib/LibPointer.sol";
 
 /// The existing `unsafeExtend` tests assert the CONTENTS of the extended array
 /// against a reference implementation. Contents alone cannot see the allocator

--- a/test/src/lib/LibUint256Array.arrayFrom.t.sol
+++ b/test/src/lib/LibUint256Array.arrayFrom.t.sol
@@ -4,10 +4,10 @@ pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 
-import {LibUint256Array, Pointer} from "src/lib/LibUint256Array.sol";
-import {LibPointer} from "src/lib/LibPointer.sol";
+import {LibUint256Array, Pointer} from "../../../src/lib/LibUint256Array.sol";
+import {LibPointer} from "../../../src/lib/LibPointer.sol";
 
-import {LibUint256ArraySlow} from "test/lib/LibUint256ArraySlow.sol";
+import {LibUint256ArraySlow} from "../../lib/LibUint256ArraySlow.sol";
 
 contract LibUint256ArrayArrayFromTest is Test {
     using LibUint256Array for uint256;

--- a/test/src/lib/LibUint256Array.extend.t.sol
+++ b/test/src/lib/LibUint256Array.extend.t.sol
@@ -4,8 +4,8 @@ pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 
-import {LibUint256Array, Pointer} from "src/lib/LibUint256Array.sol";
-import {LibUint256ArraySlow} from "test/lib/LibUint256ArraySlow.sol";
+import {LibUint256Array, Pointer} from "../../../src/lib/LibUint256Array.sol";
+import {LibUint256ArraySlow} from "../../lib/LibUint256ArraySlow.sol";
 
 contract LibUint256ArrayExtendTest is Test {
     // This code path hits the inline extension by ensuring that c is the most

--- a/test/src/lib/LibUint256Array.pointer.t.sol
+++ b/test/src/lib/LibUint256Array.pointer.t.sol
@@ -3,7 +3,7 @@
 pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
-import {LibUint256Array, Pointer} from "src/lib/LibUint256Array.sol";
+import {LibUint256Array, Pointer} from "../../../src/lib/LibUint256Array.sol";
 
 contract LibUint256ArrayPointerTest is Test {
     using LibUint256Array for uint256[];

--- a/test/src/lib/LibUint256Array.reverse.t.sol
+++ b/test/src/lib/LibUint256Array.reverse.t.sol
@@ -3,9 +3,9 @@
 pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
-import {LibUint256Array, Pointer} from "src/lib/LibUint256Array.sol";
-import {LibPointer} from "src/lib/LibPointer.sol";
-import {LibUint256ArraySlow} from "test/lib/LibUint256ArraySlow.sol";
+import {LibUint256Array, Pointer} from "../../../src/lib/LibUint256Array.sol";
+import {LibPointer} from "../../../src/lib/LibPointer.sol";
+import {LibUint256ArraySlow} from "../../lib/LibUint256ArraySlow.sol";
 
 contract LibUint256ArrayReverseTest is Test {
     /// Test that the reverse function works as expected according to the

--- a/test/src/lib/LibUint256Array.truncate.t.sol
+++ b/test/src/lib/LibUint256Array.truncate.t.sol
@@ -3,10 +3,10 @@
 pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
-import {LibUint256Array, Pointer} from "src/lib/LibUint256Array.sol";
-import {LibPointer} from "src/lib/LibPointer.sol";
-import {OutOfBoundsTruncate} from "src/error/ErrUint256Array.sol";
-import {LibUint256ArraySlow} from "test/lib/LibUint256ArraySlow.sol";
+import {LibUint256Array, Pointer} from "../../../src/lib/LibUint256Array.sol";
+import {LibPointer} from "../../../src/lib/LibPointer.sol";
+import {OutOfBoundsTruncate} from "../../../src/error/ErrUint256Array.sol";
+import {LibUint256ArraySlow} from "../../lib/LibUint256ArraySlow.sol";
 
 contract LibUint256ArrayTruncateTest is Test {
     function truncateExternal(uint256[] memory a, uint256 newLength) external pure returns (uint256[] memory) {

--- a/test/src/lib/LibUint256Matrix.allocation.t.sol
+++ b/test/src/lib/LibUint256Matrix.allocation.t.sol
@@ -4,8 +4,8 @@ pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 
-import {LibUint256Array} from "src/lib/LibUint256Array.sol";
-import {LibUint256Matrix, LibPointer, Pointer} from "src/lib/LibUint256Matrix.sol";
+import {LibUint256Array} from "../../../src/lib/LibUint256Array.sol";
+import {LibUint256Matrix, LibPointer, Pointer} from "../../../src/lib/LibUint256Matrix.sol";
 
 /// The existing `flatten` tests assert the CONTENTS of the flattened array.
 /// `flatten` also performs an allocation, and an over-allocating `flatten`

--- a/test/src/lib/LibUint256Matrix.endPointer.t.sol
+++ b/test/src/lib/LibUint256Matrix.endPointer.t.sol
@@ -4,8 +4,8 @@ pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 
-import {LibUint256Array} from "src/lib/LibUint256Array.sol";
-import {LibUint256Matrix, LibPointer, Pointer} from "src/lib/LibUint256Matrix.sol";
+import {LibUint256Array} from "../../../src/lib/LibUint256Array.sol";
+import {LibUint256Matrix, LibPointer, Pointer} from "../../../src/lib/LibUint256Matrix.sol";
 
 /// `endPointer` on a matrix is one word past the last REFERENCE, which is not
 /// the end of any allocation. The NatSpec on `endPointer` states where the inner

--- a/test/src/lib/LibUint256Matrix.flatten.t.sol
+++ b/test/src/lib/LibUint256Matrix.flatten.t.sol
@@ -3,8 +3,8 @@
 pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
-import {LibUint256Matrix} from "src/lib/LibUint256Matrix.sol";
-import {LibUint256MatrixSlow} from "test/lib/LibUint256MatrixSlow.sol";
+import {LibUint256Matrix} from "../../../src/lib/LibUint256Matrix.sol";
+import {LibUint256MatrixSlow} from "../../lib/LibUint256MatrixSlow.sol";
 
 contract LibUint256MatrixFlattenTest is Test {
     using LibUint256Matrix for uint256[][];

--- a/test/src/lib/LibUint256Matrix.itemCount.t.sol
+++ b/test/src/lib/LibUint256Matrix.itemCount.t.sol
@@ -3,9 +3,9 @@
 pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
-import {LibUint256Matrix} from "src/lib/LibUint256Matrix.sol";
-import {LibPointer, Pointer} from "src/lib/LibPointer.sol";
-import {LibUint256MatrixSlow} from "test/lib/LibUint256MatrixSlow.sol";
+import {LibUint256Matrix} from "../../../src/lib/LibUint256Matrix.sol";
+import {LibPointer, Pointer} from "../../../src/lib/LibPointer.sol";
+import {LibUint256MatrixSlow} from "../../lib/LibUint256MatrixSlow.sol";
 
 contract LibUint256MatrixItemCountTest is Test {
     using LibUint256Matrix for uint256[][];

--- a/test/src/lib/LibUint256Matrix.matrixFrom.t.sol
+++ b/test/src/lib/LibUint256Matrix.matrixFrom.t.sol
@@ -3,10 +3,10 @@
 pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
-import {LibUint256Array} from "src/lib/LibUint256Array.sol";
-import {LibUint256Matrix, LibPointer, Pointer} from "src/lib/LibUint256Matrix.sol";
+import {LibUint256Array} from "../../../src/lib/LibUint256Array.sol";
+import {LibUint256Matrix, LibPointer, Pointer} from "../../../src/lib/LibUint256Matrix.sol";
 
-import {LibUint256MatrixSlow} from "test/lib/LibUint256MatrixSlow.sol";
+import {LibUint256MatrixSlow} from "../../lib/LibUint256MatrixSlow.sol";
 
 contract LibUint256ArrayMatrixFromTest is Test {
     using LibUint256Array for uint256;

--- a/test/src/lib/LibUint256Matrix.pointer.t.sol
+++ b/test/src/lib/LibUint256Matrix.pointer.t.sol
@@ -3,9 +3,9 @@
 pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
-import {LibUint256Matrix, Pointer} from "src/lib/LibUint256Matrix.sol";
+import {LibUint256Matrix, Pointer} from "../../../src/lib/LibUint256Matrix.sol";
 
-import {LibUint256MatrixSlow} from "test/lib/LibUint256MatrixSlow.sol";
+import {LibUint256MatrixSlow} from "../../lib/LibUint256MatrixSlow.sol";
 
 contract LibUint256MatrixPointerTest is Test {
     using LibUint256Matrix for uint256[][];


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.solmem/issues/94

## Verified against main

Branched at `9a238f4`, `origin/main` merged in at `7620643`.

The claim holds and has grown. `grep -rn 'from "\(src\|test\)/' src/ test/` returned **83** hits at `9a238f4` (the issue said 73), all in `test/src/lib/`, zero in `src/`, which already imports relatively throughout. `remappings.txt` carries only `forge-std-1.16.1/=dependencies/forge-std-1.16.1/`, so these resolve solely through foundry's project-root auto-remap — which points at the *consumer's* tree, not ours, whenever the package is consumed.

The issue's second ask — `LibStackSentinel.t.sol` reaching `LibUint256Array` indirectly through `src/lib/LibStackPointer.sol` — is **already fixed on main**: `LibStackPointer.sol` no longer exists and the import is direct from `src/lib/LibUint256Array.sol`. Only the bare-path conversion remained.

The issue predicted the convention "gets copied into a new file". It did, during this branch's life: `test/src/lib/LibArray.aliasedTail.t.sol`, landed on main by #121 after this branch was cut, arrived with two fresh bare `src/` imports. They are converted here too, bringing the total to **85**.

## Changed

Every import in `test/src/lib/**` converted to relative, matching `src/`:

| shape | before | after |
| --- | --- | --- |
| library under test | `"src/lib/X.sol"` | `"../../../src/lib/X.sol"` |
| errors | `"src/error/X.sol"` | `"../../../src/error/X.sol"` |
| slow reference impls | `"test/lib/XSlow.sol"` | `"../../lib/XSlow.sol"` |
| sibling harnesses | `"test/src/lib/XHarness.sol"` | `"./XHarness.sol"` |

Relative rather than the `rain-solmem/=src/` self-remapping the issue offers as an alternative: `.soldeerignore` drops `remappings.txt` from the package, so a remapping would split the repo's own convention between `src/` (relative) and `test/` (remapped) for no consumer-visible gain.

Imports only. No source, no test logic, no assertion changed. The full suite passes before and after with the same counts.

## QA

- **Discriminating tests:** n/a — no new tests. The change is import resolution, and the discriminator is the existing suite: it only compiles and passes if every rewritten path binds to the same file the bare path bound to. Baseline at `9a238f4` and post-change are both `349 passed, 0 failed` across 33 suites; after merging `7620643` in, `353 passed, 0 failed` across 34 suites — the 4 extra tests are `LibArray.aliasedTail.t.sol`, which main added.
- **Mutations applied:**

| # | mutation | proves | result |
| --- | --- | --- | --- |
| M1 | `src/lib/LibUint256Array.sol:399` `mstore(left, mload(right))` → `mstore(left, mload(left))` | `../../../src/lib/` binds to the real source | **KILLED** — `testReverse(uint256[])`; suite ran 5 tests, 4 passed / 1 failed |
| M2 | `test/lib/LibUint256ArraySlow.sol:165` `b[i] = a[a.length - i - 1]` → `b[i] = a[i]` | `../../lib/` binds to the real reference impl | **KILLED** — `testReverse(uint256[])`; suite ran 5 tests, 4 passed / 1 failed |
| M3 | `test/src/lib/LibMatrixFlattenWrapHarness.sol:148` `canary[3] = CANARY` → `canary[3] = SCRIBBLE` | `./` binds to the sibling harness | **SURVIVED** — 9 ran, 0 failed. That test's stated design, not a gap; see below |
| M3b | `test/src/lib/LibMatrixFlattenWrapHarness.sol:49` `mstore(matrix, 2)` → `mstore(matrix, 0)` | `./` binds to the sibling harness | **KILLED** — `testUint256ItemCountUncheckedSumUnderreportsTheTotal`, `testUint256ItemCountOverflowRevertsWithArithmeticPanic`, `testFlattenNonWrappingOversizedLengthFailsLoudly`; 9 ran, 6 passed / 3 failed |
| M4 | `test/src/lib/LibPointer.t.sol:7` `../../../src/lib/` → `../../src/lib/` | a wrong depth must not resolve | **KILLED** — `Error (6275): Source "test/src/lib/LibPointer.sol" not found` |
| M5 | `test/src/lib/LibUint256Array.reverse.t.sol:8` `../../lib/` → `../lib/` | a wrong depth must not resolve | **KILLED** — `Error (6275): Source "test/src/lib/LibUint256ArraySlow.sol" not found` |
| M6 | `test/src/lib/LibMatrix.flattenWrap.t.sol:6` `./` → `../` | a wrong depth must not resolve | **KILLED** — `Error (6275): Source "test/src/LibMatrixFlattenWrapHarness.sol" not found` |

M1–M3b break the *target file* and watch the suite notice, which is what proves each rewritten path still reaches the file it used to. M4–M6 break the *path* and watch resolution fail, which is the negative control the shape change needs: it proves the new paths resolve relatively and that no root auto-remap silently rescues a wrong one. Every run's own `Suite result` / `Ran N test suites` line is quoted, so no result rests on a filter that matched nothing.

M3's survival is the documented design of `LibMatrix.flattenWrap.t.sol`, not a gap this diff created. Its header states that every assertion lives in the success branch of a `try` so that any guard rejecting the forged count takes the empty `catch` and passes. The #62 guard is on main, so `uint256FlattenThenWriteThroughResult` reverts and the assertion never runs. Confirmed by planting `assertTrue(false, "catch taken")` in all four `catch` bodies: all four report `[FAIL: catch taken]`, 9 ran / 5 passed / 4 failed. These are regression sentinels for #62, so no mutation to that call path could have killed M3. M3b re-probes the same `./` binding through `itemCount`, which the suite does observe.

- **Oracle:** foundry's import resolver. A path either binds to the file the bare path bound to — in which case every assertion in the suite still holds — or it binds elsewhere, and either the compiler or an assertion says so. There is no third outcome, and the two mutation families cover both.
- **Category check:** the issue asks for (a) all bare `src/` and `test/` imports converted and (b) `LibStackSentinel.t.sol`'s indirect import through `LibStackPointer.sol`. (a) covers all 85 — the 73 that existed when the issue was filed, the 10 added since, and the 2 that landed on main mid-branch — and `grep -rn 'from "\(src\|test\)/' src/ test/` now returns zero. (b) was already fixed on main before this branch.

## Not done here

Nothing stops the next new test file from arriving with bare paths again, as #121's did. A mechanical guard is the durable answer, but per the org convention that rainix owns shared CI, the lint belongs in the rainix reusable workflow rather than in this repo — a separate change against a separate repo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized test imports to use repository-relative paths.
  * Improved consistency and portability across the test suite.

* **Tests**
  * Test logic and behavior remain unchanged.
  * No public or exported interfaces were modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->