### PR TITLE
Float the test/lib pragmas and anchor slither's filter_paths on path components

### DIFF
--- a/slither.config.json
+++ b/slither.config.json
@@ -1,4 +1,4 @@
 {
     "detectors_to_exclude": "assembly-usage,solc-version",
-    "filter_paths": "(forge-std|openzeppelin|test)"
+    "filter_paths": "[/](dependencies|test)[/]"
 }

--- a/test/lib/LibBytes32ArraySlow.sol
+++ b/test/lib/LibBytes32ArraySlow.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-DCL-1.0
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
-pragma solidity =0.8.25;
+pragma solidity ^0.8.25;
 
 library LibBytes32ArraySlow {
     /// Slow implementation of arrayFrom for testing purposes.

--- a/test/lib/LibBytes32MatrixSlow.sol
+++ b/test/lib/LibBytes32MatrixSlow.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-DCL-1.0
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
-pragma solidity =0.8.25;
+pragma solidity ^0.8.25;
 
 library LibBytes32MatrixSlow {
     function compareMatrices(bytes32[][] memory a, bytes32[][] memory b, uint256 expectedLength)

--- a/test/lib/LibUint256ArraySlow.sol
+++ b/test/lib/LibUint256ArraySlow.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-DCL-1.0
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
-pragma solidity =0.8.25;
+pragma solidity ^0.8.25;
 
 library LibUint256ArraySlow {
     /// Slow implementation of arrayFrom for testing purposes.

--- a/test/lib/LibUint256MatrixSlow.sol
+++ b/test/lib/LibUint256MatrixSlow.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-DCL-1.0
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
-pragma solidity =0.8.25;
+pragma solidity ^0.8.25;
 
 library LibUint256MatrixSlow {
     function compareMatrices(uint256[][] memory a, uint256[][] memory b, uint256 expectedLength)


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.solmem/issues/96

## Verified against main (`9a238f4`; `origin/main` `7620643` merged in at `2c40153`)

Both claims still hold:

- The four reference-implementation libraries in `test/lib/` — `LibUint256ArraySlow.sol`, `LibBytes32ArraySlow.sol`, `LibUint256MatrixSlow.sol`, `LibBytes32MatrixSlow.sol` — are `library` declarations carrying `pragma solidity =0.8.25;`. Every `src/` file is `^0.8.25`; every concrete test contract is `=0.8.25`. These four were the only file-kind mismatch.
- `slither.config.json` still carried `"filter_paths": "(forge-std|openzeppelin|test)"`.

**The issue's proposed replacement is wrong and was not applied.** `^(dependencies|lib|test)/` filters nothing at all.

Slither matches `filter_paths` against the *resolved absolute* path — `slither/core/slither_core.py` builds `pathlib.Path(x).resolve().as_posix()` and `re.search`es each pattern against it — after passing the pattern through `_relative_path_format`, which is `path.split("..")[-1].strip(".").strip("/")`. So `^(dependencies|lib|test)/` loses its trailing `/` and becomes `^(dependencies|lib|test)`, anchored at the start of `/home/runner/work/...`, which can never match. Proven end to end below: with the proposed pattern, slither reports a finding in `test/lib/` that both the old and the new pattern correctly suppress.

`lib` is separately wrong for this repo. Under any working anchor it would collide with `src/lib/`, and a top-level `lib/` cannot exist here — git submodules are banned org-wide and enforced by rainix's `no-submodules` action.

The issue's illustration of the current hazard is also wrong in its specifics: `src/lib/LibTester.sol` is *not* dropped, because the match is case-sensitive and `LibTester` contains no lowercase `test`. The hazard is real for a stronger reason. Because the match is against the absolute path, any *ancestor* directory containing the substring `test` silently drops every finding in the repo — `/home/dev/latest/…`, `/build/contests/…`. That turns the gate green while it is analysing nothing.

## Changed

- `test/lib/*Slow.sol` ×4: `pragma solidity =0.8.25;` → `^0.8.25;`.
- `slither.config.json`: `filter_paths` → `[/](dependencies|test)[/]`.

The character classes are load-bearing: `_relative_path_format` strips bare leading and trailing `/` from the pattern, so `/dependencies/` would degrade back to the unanchored `dependencies`. `[/]` survives the strip and anchors on whole path components. `dependencies` covers the entire soldeer root instead of two named packages (`openzeppelin` is not even a dependency of this repo), and `test` can no longer match a substring of a filename or an ancestor directory. No `src/` path can be swallowed.

For the default target, `slither .` never compiles `test/` anyway — crytic-compile shells out to `forge build --build-info --skip ./test/** ./script/** --force`, and `slither .` analyses 8 contracts, exactly the `src/` libraries. The `test` entry matters for a non-default target, which is what the last table row exercises.

## Mutation table

Probe mutant: `function PROBE_BadName(...)` added to the subject file, which slither's `naming-convention` detector reports. Slither exits **255** when it reports and **0** when it does not, so a swallowed finding is a green CI gate — killed means non-zero exit.

| # | mutant location | checkout path | `filter_paths` | slither exit | results | verdict |
|---|---|---|---|---|---|---|
| 1 | `src/lib/LibPointer.sol` | `…/i-96` | old `(forge-std\|openzeppelin\|test)` | 255 | 1 | killed |
| 2 | `src/lib/LibPointer.sol` | `…/i-96` | new `[/](dependencies\|test)[/]` | 255 | 1 | killed — no coverage lost |
| 3 | `src/lib/LibPointer.sol` | `…/latest/rain.solmem` | old | **0** | **0** | **SURVIVED** — ancestor dir `latest` swallows it |
| 4 | `src/lib/LibPointer.sol` | `…/latest/rain.solmem` | new | 255 | 1 | killed — the regression this PR fixes |
| 5 | `test/lib/LibUint256ArraySlow.sol` | `…/i-96` | old | 0 | 0 | correctly suppressed |
| 6 | `test/lib/LibUint256ArraySlow.sol` | `…/i-96` | new | 0 | 0 | correctly suppressed |
| 7 | `test/lib/LibUint256ArraySlow.sol` | `…/i-96` | issue's `^(dependencies\|lib\|test)/` | **255** | **1** | **filter disabled** — proposed fix rejected |

Rows 1–4 are the same mutant under the same config differing only in checkout path, so the run is proven live: rows 1/2/4 report and row 3 does not. Rows 5–7 are the same mutant and same path differing only in config, so row 7's finding is attributable to the pattern alone.

The pragma half has **no mutant**. `=0.8.25` and `^0.8.25` are both satisfied by the pinned solc 0.8.25, the only compiler the flake provides, so the change is inert at this toolchain and no test in this repo can distinguish them. It is a convention alignment, and the repo has no automated pragma-convention check to strengthen — enforcement would belong in rainix alongside `no-submodules` and `no-custom-natspec`, not here.

## Suite

On the merge commit `2c40153`:

`nix develop -c forge test` — 353 passed, 0 failed, 0 skipped across 34 suites.
`nix develop -c forge fmt --check` — clean.
`nix develop -c slither .` — 8 contracts, 0 results, exit 0.

## Residual

Slither offers no way to anchor `filter_paths` at the project root — the match is always against the resolved absolute path. So an ancestor directory named *exactly* `dependencies` or `test` still swallows everything. That surface is far narrower than today's, which triggers on `test`, `forge-std` or `openzeppelin` appearing anywhere in the absolute path in any form, including inside a word (`latest`, `contests`, `testing`).

`include_paths` would fail loud instead of silent, but it is worse at the issue's second goal: soldeer packages use a `src/` layout of their own (`dependencies/forge-std-1.16.1/src/`), so an `src`-based whitelist cannot separate this repo's sources from a dependency's.
