### PR TITLE
Bump forge-std to 1.16.2

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -15,4 +15,4 @@ fuzz.runs = 2056
 libs = ["dependencies"]
 
 [dependencies]
-forge-std = "1.16.1"
+forge-std = "1.16.2"

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,1 +1,1 @@
-forge-std-1.16.1/=dependencies/forge-std-1.16.1/
+forge-std-1.16.2/=dependencies/forge-std-1.16.2/

--- a/soldeer.lock
+++ b/soldeer.lock
@@ -1,6 +1,6 @@
 [[dependencies]]
 name = "forge-std"
-version = "1.16.1"
-url = "https://soldeer-revisions.s3.amazonaws.com/forge-std/1_16_1_08-05-2026_08:51:16_forge-std-1.16.zip"
-checksum = "839b61832925c7152c7b6dffbfa4998d9e606211179bd8f604733124e8a7cb57"
-integrity = "60e55d10150354ca4a1e2985c5456c834b92b82ef85ab0e1d92a7786cddbd219"
+version = "1.16.2"
+url = "https://soldeer-revisions.s3.amazonaws.com/forge-std/1_16_2_03-07-2026_07:37:45_forge-std-1.16.zip"
+checksum = "405dccc9d60d753f6abc412b4adf0359f4390f65dbadbbb277a12b4946ed8969"
+integrity = "5fb4325b60d7d4194bd0481e2f94398cf1d9c6561dd12a66fb2748ef4a68205f"

--- a/test/src/lib/LibArray.aliasedTail.t.sol
+++ b/test/src/lib/LibArray.aliasedTail.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibUint256Array} from "src/lib/LibUint256Array.sol";
 import {LibBytes32Array} from "src/lib/LibBytes32Array.sol";
 

--- a/test/src/lib/LibArray.selfExtend.t.sol
+++ b/test/src/lib/LibArray.selfExtend.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibUint256Array} from "src/lib/LibUint256Array.sol";
 import {LibBytes32Array} from "src/lib/LibBytes32Array.sol";
 

--- a/test/src/lib/LibArraySlow.copySlow.t.sol
+++ b/test/src/lib/LibArraySlow.copySlow.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 
 import {LibUint256ArraySlow} from "test/lib/LibUint256ArraySlow.sol";
 import {LibBytes32ArraySlow} from "test/lib/LibBytes32ArraySlow.sol";

--- a/test/src/lib/LibBytes.t.sol
+++ b/test/src/lib/LibBytes.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibBytes, TruncateError} from "src/lib/LibBytes.sol";
 import {LibPointer, Pointer, LibMemCpy} from "src/lib/LibMemCpy.sol";
 

--- a/test/src/lib/LibBytes32Array.allocation.t.sol
+++ b/test/src/lib/LibBytes32Array.allocation.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 
 import {LibBytes32Array, Pointer} from "src/lib/LibBytes32Array.sol";
 import {LibPointer} from "src/lib/LibPointer.sol";

--- a/test/src/lib/LibBytes32Array.arrayFrom.t.sol
+++ b/test/src/lib/LibBytes32Array.arrayFrom.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 
 import {LibBytes32Array, Pointer} from "src/lib/LibBytes32Array.sol";
 import {LibPointer} from "src/lib/LibPointer.sol";

--- a/test/src/lib/LibBytes32Array.extend.t.sol
+++ b/test/src/lib/LibBytes32Array.extend.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 
 import {LibBytes32Array, Pointer} from "src/lib/LibBytes32Array.sol";
 import {LibBytes32ArraySlow} from "test/lib/LibBytes32ArraySlow.sol";

--- a/test/src/lib/LibBytes32Array.pointer.t.sol
+++ b/test/src/lib/LibBytes32Array.pointer.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibBytes32Array, Pointer} from "src/lib/LibBytes32Array.sol";
 
 contract LibBytes32ArrayPointerTest is Test {

--- a/test/src/lib/LibBytes32Array.reverse.t.sol
+++ b/test/src/lib/LibBytes32Array.reverse.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibBytes32Array, Pointer} from "src/lib/LibBytes32Array.sol";
 import {LibPointer} from "src/lib/LibPointer.sol";
 import {LibBytes32ArraySlow} from "test/lib/LibBytes32ArraySlow.sol";

--- a/test/src/lib/LibBytes32Array.truncate.t.sol
+++ b/test/src/lib/LibBytes32Array.truncate.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibBytes32Array, Pointer} from "src/lib/LibBytes32Array.sol";
 import {LibPointer} from "src/lib/LibPointer.sol";
 import {OutOfBoundsTruncate} from "src/error/ErrUint256Array.sol";

--- a/test/src/lib/LibBytes32Matrix.allocation.t.sol
+++ b/test/src/lib/LibBytes32Matrix.allocation.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 
 import {LibBytes32Array} from "src/lib/LibBytes32Array.sol";
 import {LibBytes32Matrix, LibPointer, Pointer} from "src/lib/LibBytes32Matrix.sol";

--- a/test/src/lib/LibBytes32Matrix.endPointer.t.sol
+++ b/test/src/lib/LibBytes32Matrix.endPointer.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 
 import {LibBytes32Array} from "src/lib/LibBytes32Array.sol";
 import {LibBytes32Matrix, LibPointer, Pointer} from "src/lib/LibBytes32Matrix.sol";

--- a/test/src/lib/LibBytes32Matrix.flatten.t.sol
+++ b/test/src/lib/LibBytes32Matrix.flatten.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibBytes32Matrix} from "src/lib/LibBytes32Matrix.sol";
 import {LibBytes32MatrixSlow} from "test/lib/LibBytes32MatrixSlow.sol";
 

--- a/test/src/lib/LibBytes32Matrix.itemCount.t.sol
+++ b/test/src/lib/LibBytes32Matrix.itemCount.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibBytes32Matrix} from "src/lib/LibBytes32Matrix.sol";
 import {LibPointer, Pointer} from "src/lib/LibPointer.sol";
 import {LibBytes32MatrixSlow} from "test/lib/LibBytes32MatrixSlow.sol";

--- a/test/src/lib/LibBytes32Matrix.matrixFrom.t.sol
+++ b/test/src/lib/LibBytes32Matrix.matrixFrom.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibBytes32Array} from "src/lib/LibBytes32Array.sol";
 import {LibBytes32Matrix, LibPointer, Pointer} from "src/lib/LibBytes32Matrix.sol";
 

--- a/test/src/lib/LibBytes32Matrix.pointer.t.sol
+++ b/test/src/lib/LibBytes32Matrix.pointer.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibBytes32Matrix, Pointer} from "src/lib/LibBytes32Matrix.sol";
 
 import {LibBytes32MatrixSlow} from "test/lib/LibBytes32MatrixSlow.sol";

--- a/test/src/lib/LibMatrix.flattenWrap.t.sol
+++ b/test/src/lib/LibMatrix.flattenWrap.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test, stdError} from "forge-std-1.16.1/src/Test.sol";
+import {Test, stdError} from "forge-std-1.16.2/src/Test.sol";
 import {LibMatrixFlattenWrapHarness} from "test/src/lib/LibMatrixFlattenWrapHarness.sol";
 
 /// Reproduces issue #62 for `LibUint256Matrix` and its byte identical

--- a/test/src/lib/LibMemCpy.Bytes.t.sol
+++ b/test/src/lib/LibMemCpy.Bytes.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 
 import {LibMemCpy} from "src/lib/LibMemCpy.sol";
 import {Pointer, LibBytes} from "src/lib/LibBytes.sol";

--- a/test/src/lib/LibMemCpy.Words.t.sol
+++ b/test/src/lib/LibMemCpy.Words.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 
 import {LibMemCpy} from "src/lib/LibMemCpy.sol";
 import {LibUint256Array, Pointer} from "src/lib/LibUint256Array.sol";

--- a/test/src/lib/LibPointer.t.sol
+++ b/test/src/lib/LibPointer.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 
 import {LibPointer, Pointer} from "src/lib/LibPointer.sol";
 import {LibBytes} from "src/lib/LibBytes.sol";

--- a/test/src/lib/LibStackSentinel.t.sol
+++ b/test/src/lib/LibStackSentinel.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 
 import {LibPointer, Pointer} from "src/lib/LibPointer.sol";
 import {LibUint256Array} from "src/lib/LibUint256Array.sol";

--- a/test/src/lib/LibStackSentinel.tupleSizeWrap.t.sol
+++ b/test/src/lib/LibStackSentinel.tupleSizeWrap.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibStackSentinelWrapHarness} from "test/src/lib/LibStackSentinelWrapHarness.sol";
 
 /// Reproduces the `consumeSentinelTuples` half of issue #54.

--- a/test/src/lib/LibUint256Array.allocation.t.sol
+++ b/test/src/lib/LibUint256Array.allocation.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 
 import {LibUint256Array, Pointer} from "src/lib/LibUint256Array.sol";
 import {LibPointer} from "src/lib/LibPointer.sol";

--- a/test/src/lib/LibUint256Array.arrayFrom.t.sol
+++ b/test/src/lib/LibUint256Array.arrayFrom.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 
 import {LibUint256Array, Pointer} from "src/lib/LibUint256Array.sol";
 import {LibPointer} from "src/lib/LibPointer.sol";

--- a/test/src/lib/LibUint256Array.extend.t.sol
+++ b/test/src/lib/LibUint256Array.extend.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 
 import {LibUint256Array, Pointer} from "src/lib/LibUint256Array.sol";
 import {LibUint256ArraySlow} from "test/lib/LibUint256ArraySlow.sol";

--- a/test/src/lib/LibUint256Array.pointer.t.sol
+++ b/test/src/lib/LibUint256Array.pointer.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibUint256Array, Pointer} from "src/lib/LibUint256Array.sol";
 
 contract LibUint256ArrayPointerTest is Test {

--- a/test/src/lib/LibUint256Array.reverse.t.sol
+++ b/test/src/lib/LibUint256Array.reverse.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibUint256Array, Pointer} from "src/lib/LibUint256Array.sol";
 import {LibPointer} from "src/lib/LibPointer.sol";
 import {LibUint256ArraySlow} from "test/lib/LibUint256ArraySlow.sol";

--- a/test/src/lib/LibUint256Array.truncate.t.sol
+++ b/test/src/lib/LibUint256Array.truncate.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibUint256Array, Pointer} from "src/lib/LibUint256Array.sol";
 import {LibPointer} from "src/lib/LibPointer.sol";
 import {OutOfBoundsTruncate} from "src/error/ErrUint256Array.sol";

--- a/test/src/lib/LibUint256Matrix.allocation.t.sol
+++ b/test/src/lib/LibUint256Matrix.allocation.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 
 import {LibUint256Array} from "src/lib/LibUint256Array.sol";
 import {LibUint256Matrix, LibPointer, Pointer} from "src/lib/LibUint256Matrix.sol";

--- a/test/src/lib/LibUint256Matrix.endPointer.t.sol
+++ b/test/src/lib/LibUint256Matrix.endPointer.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 
 import {LibUint256Array} from "src/lib/LibUint256Array.sol";
 import {LibUint256Matrix, LibPointer, Pointer} from "src/lib/LibUint256Matrix.sol";

--- a/test/src/lib/LibUint256Matrix.flatten.t.sol
+++ b/test/src/lib/LibUint256Matrix.flatten.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibUint256Matrix} from "src/lib/LibUint256Matrix.sol";
 import {LibUint256MatrixSlow} from "test/lib/LibUint256MatrixSlow.sol";
 

--- a/test/src/lib/LibUint256Matrix.itemCount.t.sol
+++ b/test/src/lib/LibUint256Matrix.itemCount.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibUint256Matrix} from "src/lib/LibUint256Matrix.sol";
 import {LibPointer, Pointer} from "src/lib/LibPointer.sol";
 import {LibUint256MatrixSlow} from "test/lib/LibUint256MatrixSlow.sol";

--- a/test/src/lib/LibUint256Matrix.matrixFrom.t.sol
+++ b/test/src/lib/LibUint256Matrix.matrixFrom.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibUint256Array} from "src/lib/LibUint256Array.sol";
 import {LibUint256Matrix, LibPointer, Pointer} from "src/lib/LibUint256Matrix.sol";
 

--- a/test/src/lib/LibUint256Matrix.pointer.t.sol
+++ b/test/src/lib/LibUint256Matrix.pointer.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibUint256Matrix, Pointer} from "src/lib/LibUint256Matrix.sol";
 
 import {LibUint256MatrixSlow} from "test/lib/LibUint256MatrixSlow.sol";


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.solmem/issues/97

## Verified against main

Checked at `46806c7`, then merged `origin/main` in at `7620643` (`0.1.17` release):

- `foundry.toml` still pinned `forge-std = "1.16.1"`, with `soldeer.lock` and `remappings.txt` agreeing. The finding was live, not stale.
- The soldeer registry still reports `1.16.2` (published 2026-07-03) as the newest published revision. Nothing newer has landed since the issue was filed.
- `forge-std` is test-only here: zero references under `src/`, and `.soldeerignore` excludes `/test` and `/dependencies`, so the published package is untouched by this.
- The file count in the issue has moved: 34 test files imported `forge-std-1.16.1/src/Test.sol` on main, not 28.

The pin is the org-wide baseline rather than a decision about `1.16.1` in particular — `rain.math.binary`, `rain.math.fixedpoint`, `rain.interpreter`, `rain.orderbook`, `rain.factory`, `rain.verify`, `rain.merkle`, `rain.extrospection` and `rain.lib.typecast` all sit on `1.16.1` too, and nothing in this repo records an intent to hold it there. So this takes the issue's first arm and bumps, which retires the finding outright rather than parking a comment that asserts an intent.

What `1.16.1 -> 1.16.2` contains for the surfaces this suite uses (`Test`, `stdError`, `vm`, the `assert*` family): `Test.sol` is byte identical; `StdAssertions.sol`, `StdMath.sol`, `StdUtils.sol` and `StdCheats.sol` differ only by private constant renames (`FAILED_SLOT` -> `_FAILED_SLOT`, `UINT256_MAX` -> `_UINT256_MAX`, and so on) and added NatSpec. No behaviour reaching this repo changes.

## Changed

- `foundry.toml`: `forge-std = "1.16.2"`.
- `soldeer.lock`: regenerated by `forge soldeer update`.
- `remappings.txt`: `forge-std-1.16.2/=dependencies/forge-std-1.16.2/`. `soldeer update` appends without pruning, so the stale `1.16.1` line was deleted by hand.
- 34 test files: import prefix `forge-std-1.16.1/` -> `forge-std-1.16.2/`. Versioned import prefixes are the convention, so the version moves in place.

`nix develop -c forge test` on the merge commit `27b8bf6`: 353 tests passed, 0 failed, across 34 suites — the same counts as `1.16.1` before the bump. `nix develop -c forge fmt --check` clean.

## Mutation table

The changed artefact is the test harness itself, so the hazard is a bump that leaves the suite compiling and reporting success while its assertions no longer bite. Each mutant below breaks source behaviour under `forge-std-1.16.2` and reaches a different forge-std assertion surface. Every row carries the unmutated baseline for the same filter, so a zero-match filter cannot pass itself off as a survivor: the pass counts are non-zero and the mutated totals match them.

| # | Mutation | Filter, unmutated | Mutated | Killed by | forge-std surface proven |
| --- | --- | --- | --- | --- | --- |
| M1 | `LibMemCpy.unsafeCopyWordsTo`: `mcopy(target, source, mul(length, 0x20))` -> `mul(length, 0x1f)` | `LibMemCpy.Words.t.sol`, 12 passed | 1 passed, 11 failed | `testCopySimple` (`[1, 2, 3] != [1, 2, 0]`), `testCopyWordsDirection`, `testCopyWordsOverlapForward`/`Backward`, `testCopyFuzz`, `testCopyMultiWordFuzz`, `testCopyDirtyTargetFuzz`, `testCopyMaxSuffixFuzz` | `assertEq` over `uint256[]` and scalars, incl. fuzzed |
| M2 | `LibUint256Array.truncate`: `newLength > array.length` -> `newLength > array.length + 1` | `LibUint256Array.truncate.t.sol`, 8 passed | 5 passed, 3 failed | `testTruncateEmptyToOneReverts`, `testTruncateOneTooLongReverts`, `testTruncateError` — all `next call did not revert as expected` | `vm.expectRevert` with custom error args |
| M3 | `LibUint256Matrix.itemCount` overflow panic code: `mstore(0x20, 0x11)` -> `mstore(0x20, 0x12)` | `LibMatrix.flattenWrap.t.sol`, 9 passed | 8 passed, 1 failed | `testUint256ItemCountOverflowRevertsWithArithmeticPanic` — `panic: division or modulo by zero (0x12) != panic: arithmetic underflow or overflow (0x11)` | `stdError.arithmeticError` revert-data matching |
| M4 | `LibUint256Array.reverse`: `lt(left, right)` -> `lt(left, sub(right, 0x20))` (drops the middle swap) | `LibUint256Array.reverse.t.sol`, 5 passed | 4 passed, 1 failed | `testReverse` — counterexample `[0, 5012] != [5012, 0]` | fuzzer generating a discriminating input |

Four mutants, four killed, none survived. `git status` after the pass shows no `src/` edits — every mutant was reverted.

## QA
- Discriminating tests: no new tests — this changes no source behaviour. The four existing tests used as discriminators are `testCopySimple`, `testTruncateOneTooLongReverts`, `testUint256ItemCountOverflowRevertsWithArithmeticPanic` and `testReverse`; each passes on the unmutated branch (baselines above: 12, 8, 9 and 5 passed for their filters) and each fails under its mutant, verified by running the filter both ways under `forge-std-1.16.2`.
- Mutations applied: `LibMemCpy.sol` `mul(length, 0x20)` -> `mul(length, 0x1f)` killed by `testCopySimple` plus 10 others; `LibUint256Array.sol` `newLength > array.length` -> `newLength > array.length + 1` killed by `testTruncateOneTooLongReverts` plus 2 others; `LibUint256Matrix.sol` `mstore(0x20, 0x11)` -> `mstore(0x20, 0x12)` killed by `testUint256ItemCountOverflowRevertsWithArithmeticPanic`; `LibUint256Array.sol` `lt(left, right)` -> `lt(left, sub(right, 0x20))` killed by `testReverse`. Full table above.
- Oracle: the soldeer registry API for the newest published `forge-std` revision, and a direct file diff of `dependencies/forge-std-1.16.1` against `dependencies/forge-std-1.16.2` for what the bump contains. Neither reads the repo's own claims about itself.
- Category check: the issue asks (a) confirm whether the `1.16.1` pin is deliberate, and (b) either bump or record the intent. Covered: (a) answered from evidence — no recorded intent in this repo and nine sibling repos on the same version, so it is an org baseline rather than a decision about `1.16.1`; (b) bumped, which is the issue's first arm.
