### PR TITLE
Name unsafeExtend's arrays and the sentinel tuple size, and point the matrix tests at their subject

### DIFF
--- a/src/lib/LibBytes32Array.sol
+++ b/src/lib/LibBytes32Array.sol
@@ -299,12 +299,13 @@ library LibBytes32Array {
         }
     }
 
-    /// Extends `base_` with `extend_` by allocating only an additional
-    /// `extend_.length` words onto `base_` and copying only `extend_` if
-    /// possible. If `base_` is large this MAY be significantly more efficient
-    /// than allocating `base_.length + extend_.length` for an entirely new array
-    /// and copying both `base_` and `extend_` into the new array one item at a
-    /// time in Solidity.
+    /// Extends `baseArray` with `extendArray` by allocating only an additional
+    /// `extendArray.length` words onto `baseArray` and copying only
+    /// `extendArray` if possible. If `baseArray` is large this MAY be
+    /// significantly more efficient than allocating
+    /// `baseArray.length + extendArray.length` for an entirely new array and
+    /// copying both `baseArray` and `extendArray` into the new array one item
+    /// at a time in Solidity.
     ///
     /// The efficient version of extension is only possible if the free memory
     /// pointer sits at the end of the base array at the moment of extension. If
@@ -328,10 +329,14 @@ library LibBytes32Array {
     /// Both arrays MUST be valid solidity memory arrays, each owning the region
     /// its own length word describes.
     ///
-    /// @param b The base integer array that will be extended by `e`.
-    /// @param e The extend integer array that extends `b`.
-    /// @return extended The extended array of `b` extended by `e`.
-    function unsafeExtend(bytes32[] memory b, bytes32[] memory e) internal pure returns (bytes32[] memory extended) {
+    /// @param baseArray The base array that will be extended by `extendArray`.
+    /// @param extendArray The extend array that extends `baseArray`.
+    /// @return extended `baseArray` extended by `extendArray`.
+    function unsafeExtend(bytes32[] memory baseArray, bytes32[] memory extendArray)
+        internal
+        pure
+        returns (bytes32[] memory extended)
+    {
         assembly ("memory-safe") {
             // Slither doesn't recognise assembly function names as mixed case
             // even if they are.
@@ -377,7 +382,7 @@ library LibBytes32Array {
                 }
             }
 
-            extended := extendInline(b, e)
+            extended := extendInline(baseArray, extendArray)
         }
     }
 

--- a/src/lib/LibStackSentinel.sol
+++ b/src/lib/LibStackSentinel.sol
@@ -88,9 +88,10 @@ type Sentinel is uint256;
 library LibStackSentinel {
     using LibStackSentinel for Pointer;
 
-    /// Given two stack pointers that bound a stack build an array of `n` item
-    /// tuples above the given sentinel value. The sentinel will be skipped and
-    /// a pointer below it returned alongside the tuples list.
+    /// Given two stack pointers that bound a stack build an array of
+    /// `tupleSize` item tuples above the given sentinel value. The sentinel
+    /// will be skipped and a pointer below it returned alongside the tuples
+    /// list.
     ///
     /// The tuples can be cast (via assembly) to structs.
     ///
@@ -107,18 +108,19 @@ library LibStackSentinel {
     /// an empty/optional/absent value they MAY provided a sentinel for a zero
     /// length array and the calling contract SHOULD handle this.
     ///
-    /// `n` is scaled to a byte stride in checked Solidity, so an `n` too large
-    /// to scale (`n > type(uint256).max / 0x20`) WILL REVERT with an arithmetic
-    /// overflow panic. Together with `n != 0` that is the only bound on `n`.
-    /// There is no check that the stack is large enough to hold whole tuples of
-    /// that stride, so the scan steps down from `upper` in strides of
-    /// `n * 0x20` BYTES and a stride that the remaining range cannot be stepped
-    /// down by steps the cursor past zero and wraps it. There is no explicit
-    /// underflow check and the resulting failure is deliberately not uniform:
-    /// almost every wrapped cursor lands at an unaddressable position, where
-    /// the read exhausts the whole gas allowance of the call frame, but a
-    /// stride within a few words of `2**256` wraps to a small step UPWARD and
-    /// the scan reads above `upper` instead.
+    /// `tupleSize` is scaled to a byte stride in checked Solidity, so a
+    /// `tupleSize` too large to scale (`tupleSize > type(uint256).max / 0x20`)
+    /// WILL REVERT with an arithmetic overflow panic. Together with
+    /// `tupleSize != 0` that is the only bound on `tupleSize`. There is no
+    /// check that the stack is large enough to hold whole tuples of that
+    /// stride, so the scan steps down from `upper` in strides of
+    /// `tupleSize * 0x20` BYTES and a stride that the remaining range cannot
+    /// be stepped down by steps the cursor past zero and wraps it. There is no
+    /// explicit underflow check and the resulting failure is deliberately not
+    /// uniform: almost every wrapped cursor lands at an unaddressable
+    /// position, where the read exhausts the whole gas allowance of the call
+    /// frame, but a stride within a few words of `2**256` wraps to a small
+    /// step UPWARD and the scan reads above `upper` instead.
     ///
     /// What IS guaranteed is that an underflowing scan cannot silently
     /// succeed. `sentinelPointer` is ALWAYS within `[lower, upper)`, and a scan
@@ -150,16 +152,17 @@ library LibStackSentinel {
     /// @param sentinel The value to expect as the sentinel. MUST be present in
     /// the stack or `consumeSentinel` will revert. MUST NOT collide with valid
     /// stack items (or be cryptographically improbable to do so).
-    /// @param n The number of items per tuple.
+    /// @param tupleSize The number of items per tuple.
     /// @return sentinelPointer Pointer to the sentinel that was found, ALWAYS
     /// within `[lower, upper)`. A missing sentinel WILL REVERT.
-    /// @return tuplesPointer Pointer to the n-item tuples array that was built.
-    function consumeSentinelTuples(Pointer lower, Pointer upper, Sentinel sentinel, uint256 n)
+    /// @return tuplesPointer Pointer to the `tupleSize` item tuples array that
+    /// was built.
+    function consumeSentinelTuples(Pointer lower, Pointer upper, Sentinel sentinel, uint256 tupleSize)
         internal
         pure
         returns (Pointer sentinelPointer, Pointer tuplesPointer)
     {
-        if (n == 0) {
+        if (tupleSize == 0) {
             revert ZeroSentinelTupleSize();
         }
         if (Pointer.unwrap(upper) < Pointer.unwrap(lower)) {
@@ -174,11 +177,11 @@ library LibStackSentinel {
         }
 
         // Each tuple takes this much space in memory. Scaled in checked
-        // Solidity, so an `n` too large to express as a byte stride reverts
-        // with an arithmetic overflow panic rather than wrapping to a small
-        // stride and serving the request as if a much smaller `n` had been
-        // asked for.
-        uint256 size = n * 0x20;
+        // Solidity, so a `tupleSize` too large to express as a byte stride
+        // reverts with an arithmetic overflow panic rather than wrapping to a
+        // small stride and serving the request as if a much smaller
+        // `tupleSize` had been asked for.
+        uint256 size = tupleSize * 0x20;
 
         // First pass to find the sentinel.
         assembly ("memory-safe") {

--- a/src/lib/LibUint256Array.sol
+++ b/src/lib/LibUint256Array.sol
@@ -299,12 +299,13 @@ library LibUint256Array {
         }
     }
 
-    /// Extends `base_` with `extend_` by allocating only an additional
-    /// `extend_.length` words onto `base_` and copying only `extend_` if
-    /// possible. If `base_` is large this MAY be significantly more efficient
-    /// than allocating `base_.length + extend_.length` for an entirely new array
-    /// and copying both `base_` and `extend_` into the new array one item at a
-    /// time in Solidity.
+    /// Extends `baseArray` with `extendArray` by allocating only an additional
+    /// `extendArray.length` words onto `baseArray` and copying only
+    /// `extendArray` if possible. If `baseArray` is large this MAY be
+    /// significantly more efficient than allocating
+    /// `baseArray.length + extendArray.length` for an entirely new array and
+    /// copying both `baseArray` and `extendArray` into the new array one item
+    /// at a time in Solidity.
     ///
     /// The efficient version of extension is only possible if the free memory
     /// pointer sits at the end of the base array at the moment of extension. If
@@ -328,10 +329,14 @@ library LibUint256Array {
     /// Both arrays MUST be valid solidity memory arrays, each owning the region
     /// its own length word describes.
     ///
-    /// @param b The base integer array that will be extended by `e`.
-    /// @param e The extend integer array that extends `b`.
-    /// @return extended The extended array of `b` extended by `e`.
-    function unsafeExtend(uint256[] memory b, uint256[] memory e) internal pure returns (uint256[] memory extended) {
+    /// @param baseArray The base array that will be extended by `extendArray`.
+    /// @param extendArray The extend array that extends `baseArray`.
+    /// @return extended `baseArray` extended by `extendArray`.
+    function unsafeExtend(uint256[] memory baseArray, uint256[] memory extendArray)
+        internal
+        pure
+        returns (uint256[] memory extended)
+    {
         assembly ("memory-safe") {
             // Slither doesn't recognise assembly function names as mixed case
             // even if they are.
@@ -377,7 +382,7 @@ library LibUint256Array {
                 }
             }
 
-            extended := extendInline(b, e)
+            extended := extendInline(baseArray, extendArray)
         }
     }
 

--- a/test/src/lib/LibBytes32Matrix.matrixFrom.t.sol
+++ b/test/src/lib/LibBytes32Matrix.matrixFrom.t.sol
@@ -8,7 +8,7 @@ import {LibBytes32Matrix, LibPointer, Pointer} from "src/lib/LibBytes32Matrix.so
 
 import {LibBytes32MatrixSlow} from "test/lib/LibBytes32MatrixSlow.sol";
 
-contract LibBytes32ArrayMatrixFromTest is Test {
+contract LibBytes32MatrixMatrixFromTest is Test {
     using LibBytes32Array for bytes32;
     using LibBytes32Matrix for bytes32[];
     using LibBytes32MatrixSlow for bytes32[];

--- a/test/src/lib/LibUint256Matrix.matrixFrom.t.sol
+++ b/test/src/lib/LibUint256Matrix.matrixFrom.t.sol
@@ -8,7 +8,7 @@ import {LibUint256Matrix, LibPointer, Pointer} from "src/lib/LibUint256Matrix.so
 
 import {LibUint256MatrixSlow} from "test/lib/LibUint256MatrixSlow.sol";
 
-contract LibUint256ArrayMatrixFromTest is Test {
+contract LibUint256MatrixMatrixFromTest is Test {
     using LibUint256Array for uint256;
     using LibUint256Matrix for uint256[];
     using LibUint256MatrixSlow for uint256[];


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.solmem/issues/95

## Verified against main first

Checked at `9a238f4`, and everything the issue claims still stood:

- `src/lib/LibUint256Array.sol` and `src/lib/LibBytes32Array.sol` declared `unsafeExtend(T[] memory b, T[] memory e)`, the doc block above them named the same two values `base_`/`extend_`, and the inner Yul helper named them `base`/`extend`. Three names for two values, on the function whose whole safety contract is which argument gets mutated.
- `src/lib/LibStackSentinel.sol` declared `consumeSentinelTuples(..., uint256 n)`.
- `test/src/lib/LibUint256Matrix.matrixFrom.t.sol:11` declared `contract LibUint256ArrayMatrixFromTest` and `test/src/lib/LibBytes32Matrix.matrixFrom.t.sol:11` declared `contract LibBytes32ArrayMatrixFromTest`, so `--match-contract LibUint256Matrix` never ran either suite.
- The issue's "checked and clean" half also still holds: no state or `immutable` variables anywhere, and no underscored local or parameter in any first-party `.sol`.

Main has since moved to `7620643`, merged in here.

## What changed

**`unsafeExtend`: `b`/`e` -> `baseArray`/`extendArray`** in both array libraries, doc block and `@param` tags following the declaration.

Not `base`/`extend` as the issue proposed — the inner Yul helper's parameters already hold those names and solc rejects the collision:

```
Error (6578): Cannot access local Solidity variables from inside an inline assembly function.
```

on every `base`/`extend` reference in the helper body. The helper keeps its own names: on the copy path its `base` is `newBase`, a fresh copy, not the caller's array.

**`consumeSentinelTuples`: `n` -> `tupleSize`**, matching `ZeroSentinelTupleSize` and `LibStackSentinel.tupleSizeWrap.t.sol`. The NatSpec and the two inline comments that named `n` follow it, and their paragraphs are rewrapped, so the diff on those lines is wider than the rename.

**Test contracts renamed** to `LibUint256MatrixMatrixFromTest` and `LibBytes32MatrixMatrixFromTest`.

`arrayFrom(uint256 a, uint256 b, ...)` is untouched — the issue rules the positional slots out of scope.

Renames and comment text only; no behaviour changed.

## Mutation table

All runs below are on the merge commit. Baseline there: `nix develop -c forge test` = 34 suites, **353 tests passed, 0 failed**, and `nix develop -c forge fmt --check` clean. Every row carries its test count, so no row is a zero-match filter faking a survivor.

| # | Mutation | Run | Result |
| --- | --- | --- | --- |
| M1 | `LibUint256Array.unsafeExtend`: `extendInline(baseArray, extendArray)` -> `extendInline(extendArray, baseArray)` | full suite, 353 tests | **KILLED**, 7 failed: `testExtendInline`, `testExtendAllocate`, `testExtendAllocateDebug`, `testExtendInlineAllocatesExactly`, `testExtendAllocateAllocatesExactly`, `testExtendInlineDoesNotWritePastFreeMemoryPointer`, `testExtendInlineEmptyExtendKeepsBasePointer` |
| M2 | `LibBytes32Array.unsafeExtend`: same argument swap | full suite, 353 tests | **KILLED**, same 7 |
| M3 | `LibStackSentinel`: `uint256 size = tupleSize * 0x20` -> `* 0x40` | full suite, 353 tests | **KILLED**, 11 failed, incl. `testConsumeSentinelTuplesMultiSize`, `testConsumeSentinelTuplesSharedSubWordOffset`, `testConsumeSentinelTuplesNegativeStrideCannotSucceedSilently` |
| M4 | `LibStackSentinel`: `if (tupleSize == 0)` -> `if (tupleSize == 1)` | full suite, 353 tests | **KILLED**, 9 failed, incl. `testConsumeSentinelTuplesNZeroError`, `testConsumeSentinelTuplesNZeroErrorPrecedence`, `testConsumeSentinelTuplesBelowLower` |
| M5a | `LibUint256Matrix`: `mstore(add(matrix, 0x60), c)` -> `..., b)`, hitting the 3+ argument `matrixFrom` overloads that no other matrix suite calls | `--match-contract LibUint256Matrix`, this branch: 6 suites, **41 tests** | **KILLED**, 1 failed: `testMatrixFromABC` |
| M5b | same mutation, test contract renamed back to main's `LibUint256ArrayMatrixFromTest` | same filter: 5 suites, **32 tests** | **SURVIVED** — the `matrixFrom` suite is outside the filter, its 9 tests never run |
| M6a | `LibBytes32Matrix`: same mutation | `--match-contract LibBytes32Matrix`, this branch: 6 suites, **41 tests** | **KILLED**, 1 failed: `testMatrixFromABC` |
| M6b | same mutation, test contract renamed back to main's `LibBytes32ArrayMatrixFromTest` | same filter: 5 suites, **32 tests** | **SURVIVED** |

M5b/M6b are the finding itself: on main that filter silently drops a whole suite, and a real defect in `matrixFrom` walks through it green.

## Overlap

https://github.com/rainlanguage/rain.solmem/pull/136 (issue #84) rewrites the same `unsafeExtend` doc block to say `b`/`e`, matching main's declaration. This renames the declaration instead, so whichever lands second merges main in and keeps the declared names.

## QA
- Discriminating tests: no new tests — this is a rename. The existing `LibUint256MatrixMatrixFromTest`/`LibBytes32MatrixMatrixFromTest` suites become discriminating under `--match-contract LibUint256Matrix`/`LibBytes32Matrix` for the first time: M5b/M6b show the same mutant surviving that filter under main's contract names (32 tests run) and dying under the new names (41 tests run, `testMatrixFromABC` fails).
- Mutations applied: `extendInline(baseArray, extendArray)` -> `extendInline(extendArray, baseArray)` in `LibUint256Array` -> killed by `testExtendInline` +6; same in `LibBytes32Array` -> killed by the same 7; `uint256 size = tupleSize * 0x20` -> `* 0x40` -> killed by `testConsumeSentinelTuplesMultiSize` +10; `if (tupleSize == 0)` -> `if (tupleSize == 1)` -> killed by `testConsumeSentinelTuplesNZeroError` +8; `mstore(add(matrix, 0x60), c)` -> `..., b)` in both matrix libraries -> killed by `testMatrixFromABC` under the new contract names, survives under main's.
- Oracle: the issue's naming rule plus the compiler. The renames are behaviour-preserving by construction, so the oracle for "nothing moved" is the unmutated suite (353 tests, 0 failed) and the four src mutations above, each of which still dies exactly where it died before the rename. `forge fmt --check` is the formatting oracle.
- Category check: issue asks (a) rename the two misnamed matrix test contracts, (b) rename `b`/`e` on `unsafeExtend` in both array libraries with the `@param` tags and inner call site, (c) rename `n` on `consumeSentinelTuples`. Covered a, b, c. (b) lands as `baseArray`/`extendArray` rather than the issue's proposed `base`/`extend`, which solc rejects (error 6578) against the inner Yul helper's own parameters. The issue's explicit non-finding (`arrayFrom`'s positional `a`..`h`) is left alone.
