### PR TITLE
Protofire's report under Protofire's copyright, and a private disclosure channel

### DIFF
--- a/LICENSES/LicenseRef-Proprietary.txt
+++ b/LICENSES/LicenseRef-Proprietary.txt
@@ -1,0 +1,2 @@
+No license is granted. All rights are reserved by the copyright holder named in
+the file's SPDX-FileCopyrightText.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ Tag `v<x.y.z>` on `main`. The
 `forge soldeer push rain-solmem~<x.y.z>` on every `v*` tag. The package name is
 derived from the repo name with `.` substituted for `-`.
 
+## Versioning
+
+Releases are `0.y.z`. A patch bump MAY change behaviour, so pin an exact
+`rain-solmem~<x.y.z>` and read the diff before taking a new one.
+
 ## License
 
 DecentraLicense 1.0 (DCL-1.0) — full text in
@@ -81,7 +86,15 @@ locally:
 nix develop -c rainix-sol-legal
 ```
 
+## Security
+
+Memory-safety bugs get reported privately. See [`SECURITY.md`](SECURITY.md).
+
 ## Contributions
 
 Welcome under the same license. Contributors warrant that their contributions
 are compliant.
+
+`LibBytes32Array` and `LibBytes32Matrix` mirror `LibUint256Array` and
+`LibUint256Matrix` by hand. A change to one goes in the other, and in both test
+suites.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -4,10 +4,11 @@ version = 1
 path = [
   ".github/workflows/**/",
   ".vscode/**/",
-  "audit/**/",
+  "audit/*",
   ".audit/**",
   ".gitignore",
   "README.md",
+  "SECURITY.md",
   "flake.lock",
   "flake.nix",
   "foundry.toml",
@@ -19,3 +20,8 @@ path = [
 ]
 SPDX-FileCopyrightText = "Copyright (c) 2020 Rain Open Source Software Ltd"
 SPDX-License-Identifier = "LicenseRef-DCL-1.0"
+
+[[annotations]]
+path = ["audit/protofire/**"]
+SPDX-FileCopyrightText = "Copyright (c) 2026 Protofire"
+SPDX-License-Identifier = "LicenseRef-Proprietary"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security
+
+Report a suspected memory-safety bug privately, via a
+[security advisory](https://github.com/rainlanguage/rain.solmem/security/advisories/new),
+not a public issue. Every function here is `internal`, so `src/` is inlined into
+the bytecode of every consuming contract, and a public report is a disclosure
+against each deployment that inlined it.
+
+Anything with no memory-safety consequence goes in a normal issue.
+
+Fixes ship in the next release from `main`; there are no backports.


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.solmem/issues/99

## Verified against main (`9a238f4`; `origin/main` `7620643` merged in at `2c40153`)

Both claims still hold:

- The four reference-implementation libraries in `test/lib/` — `LibUint256ArraySlow.sol`, `LibBytes32ArraySlow.sol`, `LibUint256MatrixSlow.sol`, `LibBytes32MatrixSlow.sol` — are `library` declarations carrying `pragma solidity =0.8.25;`. Every `src/` file is `^0.8.25`; every concrete test contract is `=0.8.25`. These four were the only file-kind mismatch.
- `slither.config.json` still carried `"filter_paths": "(forge-std|openzeppelin|test)"`.

**The issue's proposed replacement is wrong and was not applied.** `^(dependencies|lib|test)/` filters nothing at all.

Slither matches `filter_paths` against the *resolved absolute* path — `slither/core/slither_core.py` builds `pathlib.Path(x).resolve().as_posix()` and `re.search`es each pattern against it — after passing the pattern through `_relative_path_format`, which is `path.split("..")[-1].strip(".").strip("/")`. So `^(dependencies|lib|test)/` loses its trailing `/` and becomes `^(dependencies|lib|test)`, anchored at the start of `/home/runner/work/...`, which can never match. Proven end to end below: with the proposed pattern, slither reports a finding in `test/lib/` that both the old and the new pattern correctly suppress.

`lib` is separately wrong for this repo. Under any working anchor it would collide with `src/lib/`, and a top-level `lib/` cannot exist here — git submodules are banned org-wide and enforced by rainix's `no-submodules` action.

The issue's illustration of the current hazard is also wrong in its specifics: `src/lib/LibTester.sol` is *not* dropped, because the match is case-sensitive and `LibTester` contains no lowercase `test`. The hazard is real for a stronger reason. Because the match is against the absolute path, any *ancestor* directory containing the substring `test` silently drops every finding in the repo — `/home/dev/latest/…`, `/build/contests/…`. That turns the gate green while it is analysing nothing.

## Changed

- `test/lib/*Slow.sol` ×4: `pragma solidity =0.8.25;` → `^0.8.25;`.
- `slither.config.json`: `filter_paths` → `[/](dependencies|test)[/]`.

The character classes are load-bearing: `_relative_path_format` strips bare leading and trailing `/` from the pattern, so `/dependencies/` would degrade back to the unanchored `dependencies`. `[/]` survives the strip and anchors on whole path components. `dependencies` covers the entire soldeer root instead of two named packages (`openzeppelin` is not even a dependency of this repo), and `test` can no longer match a substring of a filename or an ancestor directory. No `src/` path can be swallowed.

For the default target, `slither .` never compiles `test/` anyway — crytic-compile shells out to `forge build --build-info --skip ./test/** ./script/** --force`, and `slither .` analyses 8 contracts, exactly the `src/` libraries. The `test` entry matters for a non-default target, which is what the last table row exercises.

## Mutation table

Probe mutant: `function PROBE_BadName(...)` added to the subject file, which slither's `naming-convention` detector reports. Slither exits **255** when it reports and **0** when it does not, so a swallowed finding is a green CI gate — killed means non-zero exit.

| # | mutant location | checkout path | `filter_paths` | slither exit | results | verdict |
|---|---|---|---|---|---|---|
| 1 | `src/lib/LibPointer.sol` | `…/i-96` | old `(forge-std\|openzeppelin\|test)` | 255 | 1 | killed |
| 2 | `src/lib/LibPointer.sol` | `…/i-96` | new `[/](dependencies\|test)[/]` | 255 | 1 | killed — no coverage lost |
| 3 | `src/lib/LibPointer.sol` | `…/latest/rain.solmem` | old | **0** | **0** | **SURVIVED** — ancestor dir `latest` swallows it |
| 4 | `src/lib/LibPointer.sol` | `…/latest/rain.solmem` | new | 255 | 1 | killed — the regression this PR fixes |
| 5 | `test/lib/LibUint256ArraySlow.sol` | `…/i-96` | old | 0 | 0 | correctly suppressed |
| 6 | `test/lib/LibUint256ArraySlow.sol` | `…/i-96` | new | 0 | 0 | correctly suppressed |
| 7 | `test/lib/LibUint256ArraySlow.sol` | `…/i-96` | issue's `^(dependencies\|lib\|test)/` | **255** | **1** | **filter disabled** — proposed fix rejected |

Rows 1–4 are the same mutant under the same config differing only in checkout path, so the run is proven live: rows 1/2/4 report and row 3 does not. Rows 5–7 are the same mutant and same path differing only in config, so row 7's finding is attributable to the pattern alone.

The pragma half has **no mutant**. `=0.8.25` and `^0.8.25` are both satisfied by the pinned solc 0.8.25, the only compiler the flake provides, so the change is inert at this toolchain and no test in this repo can distinguish them. It is a convention alignment, and the repo has no automated pragma-convention check to strengthen — enforcement would belong in rainix alongside `no-submodules` and `no-custom-natspec`, not here.

## Suite

On the merge commit `2c40153`:

`nix develop -c forge test` — 353 passed, 0 failed, 0 skipped across 34 suites.
`nix develop -c forge fmt --check` — clean.
`nix develop -c slither .` — 8 contracts, 0 results, exit 0.

## Residual

Slither offers no way to anchor `filter_paths` at the project root — the match is always against the resolved absolute path. So an ancestor directory named *exactly* `dependencies` or `test` still swallows everything. That surface is far narrower than today's, which triggers on `test`, `forge-std` or `openzeppelin` appearing anywhere in the absolute path in any form, including inside a word (`latest`, `contests`, `testing`).

`include_paths` would fail loud instead of silent, but it is worse at the issue's second goal: soldeer packages use a `src/` layout of their own (`dependencies/forge-std-1.16.1/src/`), so an `src`-based whitelist cannot separate this repo's sources from a dependency's.

## QA
- Discriminating tests: n/a — no Solidity changed; the executable check here is `reuse lint` + `reuse spdx` (CI runs `reuse lint`). On base, `reuse lint` passes at 67/67 while `reuse spdx` attributes the Protofire PDF to Rain / `LicenseRef-DCL-1.0`; on this branch it is Protofire / `LicenseRef-Proprietary` at 68/68.
- Mutations applied: `REUSE.toml` delete the `audit/protofire/**` block → lint FAILS 67/68 (killed by CI's `reuse lint`); that block re-asserts Rain / DCL-1.0 → lint passes 68/68, SURVIVES, caught only by `reuse spdx` attribution; delete `LICENSES/LicenseRef-Proprietary.txt` → lint FAILS `Missing licenses`; drop `SECURITY.md` from the Rain path list → lint FAILS 67/68; widen `audit/*` back to `audit/**` → passes, attribution still Protofire, SURVIVES (later block wins); add `audit/audits.json` → passes 69/69, attributed Rain / DCL-1.0.
- Oracle: the PDF's own provenance — it is Protofire's work product delivered to Rain, so Rain holds no copyright in it and grants no license over it; `reuse spdx`'s per-file output is read as the attribution the metadata actually produces, independent of what `reuse lint` reports.
- Category check: #99 asks for (A) a private disclosure channel, (B) a versioning policy, (C) the contributor constraints, (D) correct licensing metadata on the Protofire report. Covered A (SECURITY.md + private vulnerability reporting enabled on the repo), B (README `## Versioning`), D (REUSE.toml split). C partially: the mirror lockstep is stated here; the audited-commit record is #88/PR #137 and the release trigger is #98, both open and owned there.