### PR TITLE
Drop foundry.toml release metadata: version intent lives in next-v tags (rainix#335)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,12 +115,12 @@ Publishing is merge-driven; there is no release tag to push. On every push to
 `main`, [`Package Release`](.github/workflows/package-release.yaml) calls
 rainix's `rainix-autopublish`, which compares the package content against the
 latest published revision. If it differs, it runs
-`forge soldeer push rain-solmem~<version>`, tags `sol-v<version>`, and commits a
-bump of `[package] version` back to `main`.
+`forge soldeer push rain-solmem~<version>` and tags `sol-v<version>`.
 
-`[package] version` in `foundry.toml` is the **next, unpublished** version, not
-the current one. It is always one ahead of the registry; do not "correct" it to
-match.
+The publish version is derived from the Soldeer registry and git tags, never
+from `foundry.toml`: it is the semver max of a patch bump of the newest
+published version and the newest `next-v<x.y.z>` tag merged into the pushed
+head. Push a `next-v<x.y.z>` tag to request a deliberate minor or major jump.
 
 Everything [`.soldeerignore`](.soldeerignore) does not exclude ships — `src/**`,
 `README.md`, `LICENSE`, `LICENSES/`, `REUSE.toml` — and any change to it

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,11 +1,3 @@
-# Release metadata, not foundry config. `rainix-autopublish` reads `version` as
-# the next, unpublished Soldeer release and rewrites it when it publishes.
-# `[external.*]` is the section foundry reserves for another tool's config and
-# ignores; any other unreserved section it reads as a profile and warns about.
-[external.package]
-name = "rain-solmem"
-version = "0.1.27"
-
 [profile.default]
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config


### PR DESCRIPTION
Deletes the foundry.toml release-metadata section per https://github.com/rainlanguage/rainix/issues/335. Since https://github.com/rainlanguage/rainix/pull/336 merged, rainix-autopublish derives the publish version from the Soldeer registry plus `next-v*` git tags; the section is never read, and the autopublish content gate excludes it (including its attached comment block) from the content hash, so this deletion is content-neutral: it cannot mint a spurious release and changes no behavior. Also rewrites the README Publish section, which still described the pre-#336 flow (version bump committed back to main; `[package] version` as next unpublished version).

## QA
- Discriminating tests: n/a - config-metadata deletion; nothing reads the section since rainix#336 (local `nix develop -c reuse lint` green; `forge soldeer install` + `forge test`: 391 passed, 0 failed)
- Mutations applied: n/a - no code changed
- Oracle: rainix#336 gate semantics (section excluded from content hash; version from registry + next-v tags)
- Category check: issue asks removal of release metadata from consumers; covered exactly for this repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated publishing guidance to explain the new automatic release-versioning process.
  * Documented support for requesting minor or major version increases through release tags.

* **Chores**
  * Removed obsolete package release metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->